### PR TITLE
Register handler to copy all processed strings

### DIFF
--- a/plugins/xrefer/core/view.py
+++ b/plugins/xrefer/core/view.py
@@ -322,7 +322,10 @@ class XReferView(idaapi.simplecustviewer_t):
                 tooltip = 'Copy all relevant strings to the clipboard'
                 label = 'Copy all relevant strings to clipboard'
                 register_popup_action(form, popup, menu_path, menu_id, label, CopyInterestingStringsHandler(), tooltip)
-
+                menu_id = 'XRefer:copy_processed_strings'
+                tooltip = 'Copy all processed strings to clipboard'
+                label = 'Copy all processed strings to clipboard'
+                register_popup_action(form, popup, menu_path, menu_id, label, CopyProcessedStringsHandler(), tooltip)
 
         class RebaseHook(ida_idp.IDB_Hooks):
             def __init__(self, xrefer_view: 'XReferView'):


### PR DESCRIPTION
This PR introduces a new right-click menu option under the "XRefer" submenu to copy all processed strings to the clipboard.

Related to #8 