### PR TITLE
add end_last_boundary_results transition to fix exception

### DIFF
--- a/plugins/xrefer/core/state_machine.py
+++ b/plugins/xrefer/core/state_machine.py
@@ -57,6 +57,7 @@ class XReferStateMachine(StateMachine):
     start_xref_listing = base.to(xref_listing) | search.to(xref_listing) | interesting_artifacts.to(xref_listing)
     start_boundary_results = base.to(boundary_results)
     start_last_boundary_results = base.to(last_boundary_results)
+    end_last_boundary_results = last_boundary_results.to(base)
     start_interesting_artifacts = base.to(interesting_artifacts)
     start_cluster_graphs = base.to(cluster_graphs) | clusters.to(cluster_graphs)
 


### PR DESCRIPTION
The show last boundary scan results feature throws AttributeError because end_last_boundary_results() method was missing from the state machine.

Added the missing transition in state_machine.py to maintain symmetry with start_last_boundary_results.

Closes #18 .

I am Vasanth , 3rd year BE cybersecurity.

This is my first PR for the GSoC this year so it possible share me some insights . i am interested to contribute the Xrefer [Build a Multi-Backend Abstraction Layer with Binary Ninja Support] . i have issue with IDA pro to use xrefer plugin as i am trying with IDA free. 