### PR TITLE
Bump version to 1.0.4 and align metadata for hcli indexing

### DIFF
--- a/ida-plugin.json
+++ b/ida-plugin.json
@@ -3,7 +3,7 @@
   "plugin": {
     "name": "xrefer",
     "entryPoint": "plugins/xrefer.py",
-    "version": "1.0",
+    "version": "1.0.4",
     "description": "Context-aware binary navigator with LLM-powered cluster analysis and multi-source data integration",
     "license": "Apache-2.0",
     "urls": {

--- a/plugins/xrefer/core/action_handlers.py
+++ b/plugins/xrefer/core/action_handlers.py
@@ -322,7 +322,7 @@ class AboutDialogHandler(idaapi.action_handler_t):
         layout.addWidget(title_label)
         
         # Add version
-        version_label = QtWidgets.QLabel("Version 1.0.2")
+        version_label = QtWidgets.QLabel("Version 1.0.4")
         version_font = version_label.font()
         version_font.setPointSize(9)
         version_label.setFont(version_font)

--- a/plugins/xrefer/plugin.py
+++ b/plugins/xrefer/plugin.py
@@ -33,7 +33,7 @@ class XReferPlugin(idaapi.plugin_t):
         wanted_name (str): Display name of the plugin in IDA.
         wanted_hotkey (str): Default hotkey to activate the plugin.
         xrefer_view (Optional[XReferView]): The plugin's main view instance.
-        version (float): Plugin version number.
+        version (str): Plugin version (semantic version string).
     """
     flags: int = idaapi.PLUGIN_KEEP
     wanted_name: str = "XRefer"
@@ -42,7 +42,7 @@ class XReferPlugin(idaapi.plugin_t):
     def __init__(self):
         """Initialize plugin with empty view."""
         self.xrefer_view = None
-        self.version = 1.0
+        self.version = "1.0.4"
 
     def init(self) -> int:
         """


### PR DESCRIPTION
This PR bumps the plugin version to `1.0.4` and aligns the internal version string with `ida-plugin.json`.

The plugin is currently not visible via `hcli plugin search` and cannot be installed using `hcli plugin install` because the [Hex-Rays indexer](https://hexrayssa.github.io/plugin-repository/logs/indexer.html) ignores releases published prior to the plugin manager cutoff date.

<img width="825" height="520" alt="image" src="https://github.com/user-attachments/assets/41d5f89f-96d2-4167-9358-28c4478c3430" />


Hex-Rays indexer runs approximately [every 4 hours](https://github.com/HexRaysSA/plugin-repository/actions/workflows/sync.yml). After the new release is published, I will verify during the next indexing cycle that the plugin is properly indexed.

This addresses the issue reported in #33