### PR TITLE
Add backend foundation for future XRefer adapters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.venv/
+__pycache__/
+*.pyc

--- a/scripts/ida_backend_smoke.py
+++ b/scripts/ida_backend_smoke.py
@@ -1,0 +1,31 @@
+"""Test the IDA backend adapter inside an IDA Python runtime.
+Run this from IDA with a database already open and auto-analysis complete:
+    File -> Script file -> scripts/ida_backend_smoke.py
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+def main() -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    if str(repo_root) not in sys.path:
+        sys.path.insert(0, str(repo_root))
+    from xrefer_new.backend.ida import IDABackEnd
+    backend = IDABackEnd()
+    validation_issues = backend.validate()
+    print("[xrefer_new] backend:", backend.name)
+    print("[xrefer_new] image_base:", hex(backend.get_image_base()))
+    print("[xrefer_new] sha256:", backend.get_input_sha256())
+    print("[xrefer_new] entry_points:", [hex(ea) for ea in backend.get_entry_points()])
+    print("[xrefer_new] validation:", validation_issues or "ok")
+    print("[xrefer_new] functions:", len(list(backend.iter_functions())))
+    print("[xrefer_new] imports:", len(list(backend.iter_imports())))
+    print("[xrefer_new] strings:", len(list(backend.iter_strings())))
+    print("[xrefer_new] callsites:", len(list(backend.iter_call_sites())))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_backend_contract.py
+++ b/tests/test_backend_contract.py
@@ -1,0 +1,104 @@
+"""Tests for the backend abstraction contract"""
+
+from __future__ import annotations
+import unittest
+from typing import Iterator, Optional, Sequence
+from xrefer_new.backend import BackEnd, CallSite, Function, ImportEntry, Segment, StringArtifact
+
+
+class FakeBackEnd(BackEnd):
+    """Simple in memory backend for contract testing"""
+
+    def __init__(
+        self,
+        functions: Sequence[Function],
+        call_sites: Sequence[CallSite],
+        entry_points: Sequence[int] = (),
+        image_base: int = 0x1000,
+    ) -> None:
+        self._functions = tuple(functions)
+        self._call_sites = tuple(call_sites)
+        self._entry_points = tuple(entry_points)
+        self._image_base = image_base
+        self._function_map = {function.start_ea: function for function in self._functions}
+
+    @property
+    def name(self) -> str:
+        return "fake"
+    def get_image_base(self) -> int:
+        return self._image_base
+
+    def get_input_sha256(self) -> Optional[str]:
+        return None
+
+    def get_entry_points(self) -> Sequence[int]:
+        return self._entry_points
+
+    def iter_segments(self) -> Iterator[Segment]:
+        return iter(())
+
+    def iter_functions(self) -> Iterator[Function]:
+        return iter(self._functions)
+
+    def get_function(self, ea: int) -> Optional[Function]:
+        return self._function_map.get(ea)
+
+    def get_function_containing(self, ea: int) -> Optional[Function]:
+        for function in self._functions:
+            if function.start_ea <= ea < function.end_ea:
+                return function
+        return None
+
+    def iter_imports(self) -> Iterator[ImportEntry]:
+        return iter(())
+
+    def iter_strings(self) -> Iterator[StringArtifact]:
+        return iter(())
+
+    def iter_call_sites(self, func_ea: Optional[int] = None) -> Iterator[CallSite]:
+        if func_ea is None:
+            return iter(self._call_sites)
+        return iter(callsite for callsite in self._call_sites if callsite.caller_ea == func_ea)
+
+
+class BackEndContractTests(unittest.TestCase):
+    def test_validate_accepts_consistent_backend(self) -> None:
+        backend = FakeBackEnd(
+            functions=(
+                Function(0x1000, 0x1010, "entry"),
+                Function(0x2000, 0x2010, "worker"),
+            ),
+            call_sites=(
+                CallSite(0x1000, 0x1004, 0x2000),
+            ),
+            entry_points=(0x1000,),
+        )
+
+        self.assertEqual(backend.validate(), [])
+
+    def test_validate_reports_missing_caller(self) -> None:
+        backend = FakeBackEnd(
+            functions=(Function(0x2000, 0x2010, "worker"),),
+            call_sites=(CallSite(0x1000, 0x1004, 0x2000),),
+        )
+        self.assertIn("missing caller", backend.validate()[0])
+
+    def test_iter_callers_and_callees_helpers(self) -> None:
+        callsite_a = CallSite(0x1000, 0x1004, 0x3000)
+        callsite_b = CallSite(0x2000, 0x2008, 0x3000)
+        backend = FakeBackEnd(
+            functions=(
+                Function(0x1000, 0x1010, "a"),
+                Function(0x2000, 0x2010, "b"),
+                Function(0x3000, 0x3010, "c"),
+            ),
+            call_sites=(callsite_a, callsite_b),
+        )
+
+        self.assertEqual(list(backend.iter_callees(0x1000)), [callsite_a])
+        self.assertEqual(list(backend.iter_callers(0x3000)), [callsite_a, callsite_b])
+
+
+if __name__ == "__main__":
+    unittest.main()
+

--- a/tests/test_callgraph.py
+++ b/tests/test_callgraph.py
@@ -1,0 +1,88 @@
+"""Tests for backend agnostic callgraph analysis"""
+
+from __future__ import annotations
+import unittest
+from xrefer_new.analysis import CallGraphAnalyzer
+from xrefer_new.backend import CallSite, Function
+from tests.test_backend_contract import FakeBackEnd
+
+class CallGraphAnalyzerTests(unittest.TestCase):
+    def test_branching_paths_are_preserved(self) -> None:
+        backend = FakeBackEnd(
+            functions=(
+                Function(0x1000, 0x1010, "entry"),
+                Function(0x2000, 0x2010, "left"),
+                Function(0x3000, 0x3010, "right"),
+                Function(0x4000, 0x4010, "leaf"),
+                Function(0x5000, 0x5010, "other_leaf"),
+            ),
+            call_sites=(
+                CallSite(0x1000, 0x1001, 0x2000),
+                CallSite(0x1000, 0x1002, 0x3000),
+                CallSite(0x2000, 0x2001, 0x4000),
+                CallSite(0x3000, 0x3001, 0x4000),
+                CallSite(0x3000, 0x3002, 0x5000),
+            ),
+            entry_points=(0x1000,),
+        )
+
+        analyzer = CallGraphAnalyzer(backend)
+        all_paths = analyzer.generate_all_simple_call_paths(0x1000)
+
+        self.assertEqual(
+            all_paths[0x4000],
+            [
+                [0x1000, 0x2000, 0x4000],
+                [0x1000, 0x3000, 0x4000],
+            ],
+        )
+        self.assertEqual(all_paths[0x5000], [[0x1000, 0x3000, 0x5000]])
+
+    def test_cycles_do_not_create_infinite_paths(self) -> None:
+        backend = FakeBackEnd(
+            functions=(
+                Function(0x1000, 0x1010, "entry"),
+                Function(0x2000, 0x2010, "loop_a"),
+                Function(0x3000, 0x3010, "loop_b"),
+                Function(0x4000, 0x4010, "leaf"),
+            ),
+            call_sites=(
+                CallSite(0x1000, 0x1001, 0x2000),
+                CallSite(0x2000, 0x2001, 0x3000),
+                CallSite(0x3000, 0x3001, 0x2000),
+                CallSite(0x3000, 0x3002, 0x4000),
+            ),
+            entry_points=(0x1000,),
+        )
+
+        analyzer = CallGraphAnalyzer(backend)
+        paths = analyzer.generate_simple_call_paths(0x1000, 0x4000)
+
+        self.assertEqual(paths, [[0x1000, 0x2000, 0x3000, 0x4000]])
+
+    def test_reachable_leaf_detection_is_entrypoint_scoped(self) -> None:
+        backend = FakeBackEnd(
+            functions=(
+                Function(0x1000, 0x1010, "entry_a"),
+                Function(0x1100, 0x1110, "entry_b"),
+                Function(0x2000, 0x2010, "shared"),
+                Function(0x3000, 0x3010, "leaf_a"),
+                Function(0x4000, 0x4010, "leaf_b"),
+            ),
+            call_sites=(
+                CallSite(0x1000, 0x1001, 0x2000),
+                CallSite(0x2000, 0x2001, 0x3000),
+                CallSite(0x1100, 0x1101, 0x4000),
+            ),
+            entry_points=(0x1000, 0x1100),
+        )
+
+        analyzer = CallGraphAnalyzer(backend)
+
+        self.assertEqual(analyzer.reachable_leaf_functions(0x1000), {0x3000})
+        self.assertEqual(analyzer.reachable_leaf_functions(0x1100), {0x4000})
+
+
+if __name__ == "__main__":
+    unittest.main()
+

--- a/tests/test_ida_backend_import.py
+++ b/tests/test_ida_backend_import.py
@@ -1,0 +1,13 @@
+"""Tests for importing the IDA backend outside an IDA runtime"""
+from __future__ import annotations
+import unittest
+from xrefer_new.backend.ida import IDABackEnd
+
+class IDABackEndImportTests(unittest.TestCase):
+    def test_constructor_raises_without_ida_runtime(self) -> None:
+        with self.assertRaises(RuntimeError):
+            IDABackEnd()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/xrefer_new/__init__.py
+++ b/xrefer_new/__init__.py
@@ -1,0 +1,7 @@
+"""Next-generation XRefer architecture primitives.
+
+This package is intentionally small and backend-focused. It establishes the
+core interfaces needed to decouple XRefer's analysis logic from any specific
+reverse-engineering platform.
+"""
+

--- a/xrefer_new/analysis/__init__.py
+++ b/xrefer_new/analysis/__init__.py
@@ -1,0 +1,6 @@
+"""Backend-agnostic analysis building blocks for XRefer."""
+
+from .callgraph import CallGraphAnalyzer, CallGraphIndex
+
+__all__ = ["CallGraphAnalyzer", "CallGraphIndex"]
+

--- a/xrefer_new/analysis/callgraph.py
+++ b/xrefer_new/analysis/callgraph.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+from collections import defaultdict, deque
+from dataclasses import dataclass, field
+from typing import Dict, Iterable, List, Optional, Set
+from xrefer_new.backend.base import BackEnd
+
+
+@dataclass
+class CallGraphIndex:
+    """Indexed callgraph"""
+    functions: Set[int] = field(default_factory=set)
+    callers_by_callee: Dict[int, Set[int]] = field(default_factory=dict)
+    callees_by_caller: Dict[int, Set[int]] = field(default_factory=dict)
+    @classmethod
+    def from_backend(cls, backend: BackEnd) -> "CallGraphIndex":
+        callers_by_callee: Dict[int, Set[int]] = defaultdict(set)
+        callees_by_caller: Dict[int, Set[int]] = defaultdict(set)
+        functions = {function.start_ea for function in backend.iter_functions()}
+
+        for callsite in backend.iter_call_sites():
+            callers_by_callee[callsite.callee_ea].add(callsite.caller_ea)
+            callees_by_caller[callsite.caller_ea].add(callsite.callee_ea)
+            functions.add(callsite.caller_ea)
+            functions.add(callsite.callee_ea)
+
+        return cls(
+            functions=functions,
+            callers_by_callee={key: set(value) for key, value in callers_by_callee.items()},
+            callees_by_caller={key: set(value) for key, value in callees_by_caller.items()},
+        )
+
+    def callers_of(self, callee_ea: int) -> Set[int]:
+        return self.callers_by_callee.get(callee_ea, set())
+
+    def callees_of(self, caller_ea: int) -> Set[int]:
+        return self.callees_by_caller.get(caller_ea, set())
+
+    def leaf_functions(self, reachable_subset: Optional[Set[int]] = None) -> Set[int]:
+        """Return functions with no outgoing edges in the provided subset."""
+        candidates = self.functions if reachable_subset is None else reachable_subset
+        return {
+            func_ea
+            for func_ea in candidates
+            if not (self.callees_of(func_ea) & candidates)
+        }
+
+class CallGraphAnalyzer:
+    """Pure python path analysis built on top of the backend abstraction"""
+
+    def __init__(self, backend: BackEnd, index: Optional[CallGraphIndex] = None) -> None:
+        self.index = index or CallGraphIndex.from_backend(backend)
+    def reachable_from(self, entrypoint: int) -> Set[int]:
+        """Return the forward-reachable subgraph from entrypoint."""
+        if entrypoint not in self.index.functions:
+            return set()
+
+        reachable = {entrypoint}
+        queue = deque([entrypoint])
+
+        while queue:
+            node = queue.popleft()
+            for callee in sorted(self.index.callees_of(node)):
+                if callee in reachable:
+                    continue
+                reachable.add(callee)
+                queue.append(callee)
+
+        return reachable
+    def reachable_leaf_functions(self, entrypoint: int) -> Set[int]:
+        """Return leaf functions reachable from entrypoint"""
+        reachable = self.reachable_from(entrypoint)
+        if not reachable:
+            return set()
+        return {
+            func_ea
+            for func_ea in self.index.leaf_functions(reachable)
+            if func_ea != entrypoint
+        }
+
+    def generate_simple_call_paths(
+        self,
+        entrypoint: int,
+        target: int,
+        max_limit: int = 10_000,
+    ) -> List[List[int]]:
+        """Generate simple call paths from entrypoint to target
+            The implementation intentionally mirrors the path-building logic
+            from the current IDA plugin, but it now consumes backend-normalized
+            call edges instead of IDA apis directly
+        """
+        if entrypoint == target:
+            return [[entrypoint]]
+        if entrypoint not in self.index.functions or target not in self.index.functions:
+            return []
+
+        all_paths: List[List[int]] = []
+        path_buffer: deque[List[int]] = deque([[target]])
+
+        while path_buffer and len(all_paths) < max_limit and len(path_buffer) < max_limit:
+            current_path = path_buffer.popleft()
+            current_target = current_path[-1]
+            callers = self.index.callers_of(current_target)
+
+            if not callers:
+                continue
+            for caller in sorted(callers):
+                if caller in current_path:
+                    continue
+
+                next_path = current_path + [caller]
+                if caller == entrypoint:
+                    path = list(reversed(next_path))
+                    if path not in all_paths:
+                        all_paths.append(path)
+                else:
+                    path_buffer.append(next_path)
+
+        return all_paths
+    def generate_all_simple_call_paths(
+        self,
+        entrypoint: int,
+        targets: Optional[Iterable[int]] = None,
+        max_limit: int = 10_000,
+    ) -> Dict[int, List[List[int]]]:
+        """Generate all simple paths from entrypoint to reachable leaves"""
+        if targets is None:
+            targets = sorted(self.reachable_leaf_functions(entrypoint))
+
+        results: Dict[int, List[List[int]]] = {}
+        for target in targets:
+            if target == entrypoint:
+                continue
+            paths = self.generate_simple_call_paths(entrypoint, target, max_limit=max_limit)
+            if paths:
+                results[target] = paths
+        return results

--- a/xrefer_new/backend/__init__.py
+++ b/xrefer_new/backend/__init__.py
@@ -1,0 +1,14 @@
+"""Backend contracts and host-specific adapters for XRefer."""
+
+from .base import BackEnd
+from .types import CallSite, Function, ImportEntry, Segment, StringArtifact
+
+__all__ = [
+    "BackEnd",
+    "CallSite",
+    "Function",
+    "ImportEntry",
+    "Segment",
+    "StringArtifact",
+]
+

--- a/xrefer_new/backend/base.py
+++ b/xrefer_new/backend/base.py
@@ -1,0 +1,114 @@
+"""Abstract backend contract for future XRefer platform adapters"""
+
+from __future__ import annotations
+from abc import ABC, abstractmethod
+from typing import Iterator, List, Optional, Sequence
+from .types import CallSite, Function, ImportEntry, Segment, StringArtifact
+
+
+class BackEnd(ABC):
+    """Standardized interface between XRefer and a disassembly host
+    The goal of this interface is to isolate analysis logic from platform APIs.
+    A backend implementation should normalize host concepts such as functions,
+    imports, and strings into the typed models defined in xrefer_new.backend.types
+    """
+
+    @property
+    @abstractmethod
+    def name(self) -> str:
+        """Return the canonical backend name"""
+
+    @abstractmethod
+    def get_image_base(self) -> int:
+        """Return the primary image base for the loaded program"""
+
+    @abstractmethod
+    def get_input_sha256(self) -> Optional[str]:
+        """Return the input file when the host can provide"""
+
+    @abstractmethod
+    def get_entry_points(self) -> Sequence[int]:
+        """Return the hosts known entry points"""
+
+    @abstractmethod
+    def iter_segments(self) -> Iterator[Segment]:
+        """Yield normalized memory segments"""
+
+    @abstractmethod
+    def iter_functions(self) -> Iterator[Function]:
+        """Yield normalized functions"""
+
+    @abstractmethod
+    def get_function(self, ea: int) -> Optional[Function]:
+        """Return the function starting at ea if present"""
+
+    @abstractmethod
+    def get_function_containing(self, ea: int) -> Optional[Function]:
+        """Return the function containing ea if present"""
+
+    @abstractmethod
+    def iter_imports(self) -> Iterator[ImportEntry]:
+        """Yield normalized imports."""
+
+    @abstractmethod
+    def iter_strings(self) -> Iterator[StringArtifact]:
+        """Yield normalized strings."""
+
+    @abstractmethod
+    def iter_call_sites(self, func_ea: Optional[int] = None) -> Iterator[CallSite]:
+        """Yield normalized call edges.
+
+        When func_ea is provided, only callsites originating from that
+        function should be returned.
+        """
+
+    def get_function_name(self, ea: int) -> str:
+        """Return the function name for a start EA or containing EA"""
+        func = self.get_function(ea)
+        if func is None:
+            func = self.get_function_containing(ea)
+        return func.name if func else ""
+
+    def iter_callers(self, callee_ea: int) -> Iterator[CallSite]:
+        """Yield callsites targeting callee_ea"""
+        for callsite in self.iter_call_sites():
+            if callsite.callee_ea == callee_ea:
+                yield callsite
+
+    def iter_callees(self, caller_ea: int) -> Iterator[CallSite]:
+        """Yield callsites originating from caller_ea"""
+        yield from self.iter_call_sites(caller_ea)
+
+    def validate(self) -> List[str]:
+        """Run lightweight backend contract validation"""
+        issues: List[str] = []
+        functions = list(self.iter_functions())
+        function_map = {}
+
+        for func in functions:
+            if func.start_ea in function_map:
+                issues.append(f"duplicate function start 0x{func.start_ea:x}")
+            function_map[func.start_ea] = func
+
+            if func.end_ea < func.start_ea:
+                issues.append(
+                    f"function 0x{func.start_ea:x} has invalid range "
+                    f"0x{func.start_ea:x}-0x{func.end_ea:x}"
+                )
+        for callsite in self.iter_call_sites():
+            caller = function_map.get(callsite.caller_ea)
+            if caller is None:
+                issues.append(
+                    f"callsite 0x{callsite.call_ea:x} references missing caller "
+                    f"0x{callsite.caller_ea:x}"
+                )
+                continue
+
+            if not (caller.start_ea <= callsite.call_ea < caller.end_ea):
+                issues.append(
+                    f"callsite 0x{callsite.call_ea:x} falls outside caller "
+                    f"0x{caller.start_ea:x}"
+                )
+
+        return issues
+

--- a/xrefer_new/backend/ida.py
+++ b/xrefer_new/backend/ida.py
@@ -1,0 +1,187 @@
+"""IDA backed implementation of the xrefer_new backend contract"""
+from __future__ import annotations
+import binascii
+from typing import Iterator, Optional, Sequence, Set
+from .base import BackEnd
+from .types import CallSite, Function, ImportEntry, Segment, StringArtifact
+
+try:
+    import ida_bytes
+    import ida_funcs
+    import ida_nalt
+    import ida_segment
+    import idaapi
+    import idautils
+    import idc
+except ImportError:  # no cover exercised only inside IDA
+    ida_bytes = None
+    ida_funcs = None
+    ida_nalt = None
+    ida_segment = None
+    idaapi = None
+    idautils = None
+    idc = None
+
+
+class IDABackEnd(BackEnd):
+    """Reference backend implementation for IDA Pro."""
+
+    def __init__(self) -> None:
+        if idaapi is None:  # no cover exercised only inside IDA
+            raise RuntimeError("IDABackEnd requires an IDA Python runtime")
+
+    @property
+    def name(self) -> str:
+        return "ida"
+
+    def get_image_base(self) -> int:
+        return idaapi.get_imagebase()
+
+    def get_input_sha256(self) -> Optional[str]:
+        sha256_bytes = ida_nalt.retrieve_input_file_sha256()
+        if not sha256_bytes:
+            return None
+        return binascii.hexlify(sha256_bytes).decode("ascii")
+
+    def get_entry_points(self) -> Sequence[int]:
+        return tuple(ea for _, _, ea, _ in idautils.Entries())
+    def iter_segments(self) -> Iterator[Segment]:
+        current = ida_segment.get_first_seg()
+        if current is None:
+            return
+
+        while current is not None:
+            yield Segment(
+                name=ida_segment.get_segm_name(current),
+                start_ea=current.start_ea,
+                end_ea=current.end_ea,
+            )
+            current = ida_segment.get_next_seg(current.start_ea)
+
+    def iter_functions(self) -> Iterator[Function]:
+        for func_ea in idautils.Functions():
+            func = self.get_function(func_ea)
+            if func is not None:
+                yield func
+
+    def get_function(self, ea: int) -> Optional[Function]:
+        func = idaapi.get_func(ea)
+        if func is None or func.start_ea != ea:
+            return None
+        return self._to_function(func)
+
+    def get_function_containing(self, ea: int) -> Optional[Function]:
+        func = idaapi.get_func(ea)
+        if func is None:
+            return None
+        return self._to_function(func)
+
+    def iter_imports(self) -> Iterator[ImportEntry]:
+        for index in range(idaapi.get_import_module_qty()):
+            module_name = idaapi.get_import_module_name(index)
+            if not module_name:
+                continue
+
+            normalized_module = module_name.lower().split("/")[-1]
+            entries = []
+
+            def collect_import(ea: int, name: str, ordinal: int) -> bool:
+                resolved_module = normalized_module
+                resolved_name = name
+
+                if name and "@@" in name:
+                    symbol_name, symbol_module = name.split("@@", 1)
+                    resolved_name = symbol_name
+                    if "_" in symbol_module:
+                        resolved_module = "_".join(symbol_module.split("_")[:-1])
+                    else:
+                        resolved_module = symbol_module
+
+                entries.append(
+                    ImportEntry(
+                        ea=ea,
+                        name=resolved_name,
+                        module=resolved_module,
+                        ordinal=ordinal,
+                    )
+                )
+                return True
+
+            idaapi.enum_import_names(index, collect_import)
+            yield from entries
+
+    def iter_strings(self) -> Iterator[StringArtifact]:
+        strings = idautils.Strings(False)
+        strings.setup(
+            strtypes=[
+                ida_nalt.STRTYPE_C,
+                ida_nalt.STRTYPE_C_16,
+                ida_nalt.STRTYPE_C_32,
+            ]
+        )
+
+        for string_item in strings:
+            str_type = idc.get_str_type(string_item.ea)
+            if str_type is None:
+                continue
+
+            value = ida_bytes.get_strlit_contents(string_item.ea, -1, str_type)
+            if not value:
+                continue
+
+            yield StringArtifact(
+                ea=string_item.ea,
+                value=value.decode("utf-8", errors="replace"),
+                encoding=str(str_type),
+            )
+
+    def iter_call_sites(self, func_ea: Optional[int] = None) -> Iterator[CallSite]:
+        if func_ea is None:
+            func_starts = tuple(idautils.Functions())
+        else:
+            func = idaapi.get_func(func_ea)
+            if func is None:
+                return
+            func_starts = (func.start_ea,)
+
+        seen: Set[tuple[int, int, int]] = set()
+
+        for function_start in func_starts:
+            func = idaapi.get_func(function_start)
+            if func is None:
+                continue
+
+            caller_ea = func.start_ea
+            for chunk_start, chunk_end in idautils.Chunks(caller_ea):
+                for head in idautils.Heads(chunk_start, chunk_end):
+                    if not ida_bytes.is_code(ida_bytes.get_full_flags(head)):
+                        continue
+                    if not idaapi.is_call_insn(head):
+                        continue
+
+                    for xref in idautils.XrefsFrom(head, 0):
+                        callee = ida_funcs.get_func(xref.to)
+                        if callee is None:
+                            continue
+
+                        edge = (caller_ea, head, callee.start_ea)
+                        if edge in seen:
+                            continue
+                        seen.add(edge)
+
+                        yield CallSite(
+                            caller_ea=caller_ea,
+                            call_ea=head,
+                            callee_ea=callee.start_ea,
+                            is_direct=True,
+                        )
+
+    def _to_function(self, func) -> Function:
+        flags = idc.get_func_flags(func.start_ea)
+        return Function(
+            start_ea=func.start_ea,
+            end_ea=func.end_ea,
+            name=idc.get_func_name(func.start_ea),
+            is_library=bool(flags & idc.FUNC_LIB),
+            is_thunk=bool(flags & idc.FUNC_THUNK),
+        )

--- a/xrefer_new/backend/types.py
+++ b/xrefer_new/backend/types.py
@@ -1,0 +1,51 @@
+"""Typed backend models shared by all XRefer host adapters"""
+
+from __future__ import annotations
+from dataclasses import dataclass
+from typing import Optional
+
+
+@dataclass(frozen=True)
+class Segment:
+    """Normalized memory segment description"""
+
+    name: str
+    start_ea: int
+    end_ea: int
+
+
+@dataclass(frozen=True)
+class Function:
+    """Normalized function description"""
+    start_ea: int
+    end_ea: int
+    name: str
+    is_library: bool = False
+    is_thunk: bool = False
+
+
+@dataclass(frozen=True)
+class ImportEntry:
+    """Normalized import entry"""
+    ea: int
+    name: str
+    module: str
+    ordinal: Optional[int] = None
+
+
+@dataclass(frozen=True)
+class StringArtifact:
+    """Normalized string entry"""
+
+    ea: int
+    value: str
+    encoding: str = "unknown"
+
+
+@dataclass(frozen=True)
+class CallSite:
+    """Normalized function-call edge"""
+    caller_ea: int
+    call_ea: int
+    callee_ea: int
+    is_direct: bool = True


### PR DESCRIPTION
### Summary

This PR lays the groundwork for making XRefer multi-backend.

It introduces a small host abstraction layer under `xrefer_new/` and moves one meaningful slice of analysis logic out of the current IDA-specific context into backend-agnostic code. The goal here is not to add a new backend immediately, but to establish a concrete contract that future adapters such as Radare2 or Vivisect can target.

### What This Adds

- A typed backend contract for normalized host data.
- Standardized models for functions, imports, strings, segments, and callsites.
- A reference IDA adapter to prove the contract against the current host.
- Backend-agnostic callgraph and path analysis helpers.
- Unit tests for the host-agnostic behavior.
- An IDA smoke-test script at `scripts/ida_backend_smoke.py` for live runtime validation.

### Why This Split

The hard part of backend expansion is not just adding another integration, but defining a stable boundary between host APIs and XRefer’s analysis logic.

This PR keeps that boundary intentionally small and starts by migrating one non-trivial area first:

- callgraph indexing
- reachability and reachable leaf discovery
- simple path enumeration

That gives future backend work a real contract and reusable tests, without trying to port the full analyzer in one large step.

### Testing

Locally verified with:

- `python3 -m unittest discover -s tests -p 'test_*.py' -v`
- `python3 -m compileall xrefer_new tests scripts/ida_backend_smoke.py`
- `python3 -c "from xrefer_new.analysis.callgraph import CallGraphAnalyzer; from xrefer_new.backend.base import BackEnd; print('imports ok')"`

Local coverage includes:

- backend contract validation
- caller/callee helper behavior
- branching path generation
- cycle handling
- entrypoint-scoped reachable leaf detection
- non-IDA import/constructor behavior for the IDA adapter

### IDA Runtime Constraint

The reference IDA adapter depends on a live IDA Python runtime, an open database, and IDA-specific APIs, so it cannot be fully exercised in a normal Python-only local test run.

To support live verification, this PR includes `scripts/ida_backend_smoke.py`, which can be run inside IDA on a machine where IDA is installed.

### Correctness Rationale

The more logic-heavy behavior has been moved into backend-agnostic Python and is covered by unit tests using fake in-memory backends. The backend contract itself is also exercised directly in tests.

The IDA adapter is intentionally thin: it mostly translates IDA APIs into normalized dataclasses rather than introducing a large amount of new analysis logic. That keeps the host-specific layer small, reviewable, and lower-risk while making the core logic easier to test outside IDA.

### Limitations

This PR is intentionally scoped as foundation work rather than a full backend port.

It does not yet:

- migrate the full analyzer
- add a non-IDA backend
- provide automated parity tests against a live IDA database

### Next Steps

Natural follow up work would be:

- extending the backend surface where needed
- moving additional artifact extraction behind the backend boundary
- implementing the first non-IDA adapter
- adding parity or integration checks on machines with IDA available
