### PR TITLE
xrefer: harden gsoc_2025 (GUI lifecycle, qtpy, clusters, LLM)

### DIFF
--- a/plugins/xrefer/core/analyzer.py
+++ b/plugins/xrefer/core/analyzer.py
@@ -1159,9 +1159,11 @@ class XRefer:
             func_artifacts, orphan_func_artifacts, _ = self._group_interesting_artifacts(entities_to_cluster)
 
             all_candidate_funcs = set(func_artifacts.keys()) | set(orphan_func_artifacts.keys())
-            # Always treat the current entry point as interesting so small binaries still cluster
-            if self.current_analysis_ep:
-                all_candidate_funcs.add(self.current_analysis_ep)
+            # NOTE: do NOT force-add self.current_analysis_ep into the candidates.
+            # On main, candidates are strictly artifact-bearing functions. Adding the
+            # EP turned it into a common ancestor on every call path, which caused
+            # otherwise-separate clusters to merge into one (regression vs. main).
+            # Reverting to main's semantics.
 
             def _fmt_func(ea: int) -> str:
                 fn = self._backend.get_function_at(ea)
@@ -1222,20 +1224,42 @@ class XRefer:
                                     # Update intermediate paths map
                                     intermediate_paths_map.update(path_intermediates)
             if not graph_paths or not root_nodes:
-                warn_msg = (
-                    "No valid call paths found; skipping cluster analysis and report generation. "
-                    f"paths_examined={paths_examined}, candidate_paths={candidate_paths_found}, low_interest_paths={low_interest_paths}, candidates={len(all_candidate_funcs)}, graph_paths={len(graph_paths)}, root_nodes={len(root_nodes)}"
-                )
-                log(warn_msg)
-                self.analysis_warnings.append(warn_msg)
-                # Keep state consistent for downstream consumers
-                self.clusters = current_clusters or []
-                self.cluster_analysis = current_analysis or {}
-                return
-
-            # Create clusters
-            log(f"Creating clusters from {len(graph_paths)} paths with {len(root_nodes)} root nodes")
-            self.clusters = ClusterManager.decompose_into_clusters(graph_paths, intermediate_paths_map, root_nodes, self.artifact_functions, backend=self._backend)
+                # No multi-candidate paths exist — typical for tiny binaries with
+                # 0-1 artifact-bearing functions. Fall back to a single degenerate
+                # cluster rooted at the entry point so the user sees something
+                # rather than an empty view. This is the same intent as the old
+                # `all_candidate_funcs.add(self.current_analysis_ep)` hack, but
+                # localized: it only triggers when normal decomposition produced
+                # nothing, so it doesn't merge naturally-separate clusters on
+                # normal-sized binaries.
+                if all_candidate_funcs and self.current_analysis_ep:
+                    log(
+                        f"No multi-candidate paths found; building degenerate single cluster "
+                        f"rooted at EP 0x{self.current_analysis_ep:x} for "
+                        f"{len(all_candidate_funcs)} candidate(s). "
+                        f"(paths_examined={paths_examined}, low_interest_paths={low_interest_paths})"
+                    )
+                    fallback = FunctionalCluster(
+                        self.current_analysis_ep, parent_cluster_id=None, backend=self._backend
+                    )
+                    fallback.nodes.update(all_candidate_funcs)
+                    self.clusters = [fallback]
+                    # Fall through so LLM analysis still labels the fallback cluster.
+                else:
+                    warn_msg = (
+                        "No valid call paths found; skipping cluster analysis and report generation. "
+                        f"paths_examined={paths_examined}, candidate_paths={candidate_paths_found}, low_interest_paths={low_interest_paths}, candidates={len(all_candidate_funcs)}, graph_paths={len(graph_paths)}, root_nodes={len(root_nodes)}"
+                    )
+                    log(warn_msg)
+                    self.analysis_warnings.append(warn_msg)
+                    # Keep state consistent for downstream consumers
+                    self.clusters = current_clusters or []
+                    self.cluster_analysis = current_analysis or {}
+                    return
+            else:
+                # Normal decomposition path.
+                log(f"Creating clusters from {len(graph_paths)} paths with {len(root_nodes)} root nodes")
+                self.clusters = ClusterManager.decompose_into_clusters(graph_paths, intermediate_paths_map, root_nodes, self.artifact_functions, backend=self._backend)
 
             # Setup and run cluster analysis
             try:
@@ -1243,8 +1267,8 @@ class XRefer:
                 # self.cluster_analysis = ClusterAnalyzer.populate_dummy_cluster_analysis(self.clusters)
                 if not self.cluster_analysis:  # Empty results usually means network issue
                     log("No analysis results obtained - likely network connectivity issue")
-                    self.clusters = current_clusters
-                    self.cluster_analysis = current_analysis
+                    self.clusters = current_clusters or []
+                    self.cluster_analysis = current_analysis or {}
                     return
 
                 log(f"Generated analysis for {len(self.cluster_analysis.get('clusters', {}))} clusters")
@@ -1294,15 +1318,15 @@ class XRefer:
                 if not isinstance(e, litellm.exceptions.RateLimitError):
                     traceback.print_exc()
                 log(f"[-] Error analyzing clusters: {str(e)}")
-                # Restore previous state
-                self.clusters = current_clusters
-                self.cluster_analysis = current_analysis
+                # Restore previous state (coerce None to empty defaults on first run)
+                self.clusters = current_clusters or []
+                self.cluster_analysis = current_analysis or {}
 
         except Exception as e:
             log(f"[-] Error in cluster analysis: {str(e)}")
-            # Restore previous state
-            self.clusters = current_clusters
-            self.cluster_analysis = current_analysis
+            # Restore previous state (coerce None to empty defaults on first run)
+            self.clusters = current_clusters or []
+            self.cluster_analysis = current_analysis or {}
         assert self.clusters is not None
         assert self.cluster_analysis is not None
 

--- a/plugins/xrefer/core/analyzer.py
+++ b/plugins/xrefer/core/analyzer.py
@@ -23,7 +23,6 @@ import shutil
 import datetime
 from collections import OrderedDict, defaultdict
 from dataclasses import dataclass
-from operator import itemgetter
 from pathlib import Path
 from time import time
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Set, Tuple, Union, Literal
@@ -49,6 +48,22 @@ except ImportError:
         print(f"Wait: {message.removeprefix('HIDECANCEL\n')}", *args, **kwargs)
     def hide_wait_box(*args, **kwargs) -> None:
         print("Wait box hidden", *args, **kwargs)
+
+
+@dataclass(frozen=True)
+class ApiCall:
+    """One observation of an API call from the trace.
+
+    Backend-agnostic record. Rendering (color, address visibility, etc.)
+    is the consumer's responsibility — the analyzer never produces
+    presentation-layer strings.
+    """
+
+    index: int
+    call_addr: int
+    api_name: str  # full module-qualified name, e.g. "kernel32.CreateFileW"
+    call_str: str  # plain "(args) = ret"
+    count: int
 
 
 class EntityType(enum.IntEnum):
@@ -2268,43 +2283,15 @@ class XRefer:
             pass
         return capa_matches
 
-    def get_direct_calls(self, api_name: str, func_ea: int, colorized: bool = True) -> Tuple[str, ...]:
-        """
-        Retrieve direct API calls for a specific API within a given function.
+    def get_direct_calls(self, api_name: str, func_ea: int) -> Tuple[Tuple[str, int], ...]:
+        """Direct API calls of `func_ea` matching `api_name`, as ((call_str, count), ...).
 
-        This method searches for all instances where the specified API is directly
-        called within the function identified by func_ea.
-
-        Args:
-            api_name (str): The full name of the API to search for, including the module name
-                        (e.g., "kernel32.CreateFileW").
-            func_ea (int): The effective address (EA) of the function to search within.
-            colorized (bool): Whether to return color-coded call strings (True) or
-                            plain call strings (False). Default is True for backward compatibility.
-
-        Returns:
-            Tuple[Tuple[str, int], ...]: A tuple of tuples, where each inner tuple contains:
-                - str: The API call string formatted as "(<arg1>, <arg2>, ...) = <return_value>"
-                - int: Number of times this exact call signature was seen
-
-        Note:
-            If colorized=True, the returned call strings will contain IDA color codes.
-            If colorized=False, the call strings will have identical formatting but no color codes.
+        `call_str` is plain text — apply gui-layer formatting
+        (e.g. xrefer.gui.helpers.colorize_api_call) to render with color.
         """
         func_data = self.api_trace_data.get(func_ea, {})
         api_calls = func_data.get(api_name, [])
-
-        if colorized:
-            return tuple((call["call_str"], call["count"]) for call in api_calls)
-        else:
-            # Reconstruct call strings without color codes
-            plain_calls = []
-            for call in api_calls:
-                args_str = f"({', '.join(call['args'])})"
-                return_str = str(call["return_value"])
-                plain_call = f"{args_str} = {return_str}"
-                plain_calls.append((plain_call, call["count"]))
-            return tuple(plain_calls)
+        return tuple((call["call_str"], call["count"]) for call in api_calls)
 
     def get_indirect_calls(self, api_name: str, func_ea: int) -> Tuple[str, ...]:
         """
@@ -2340,96 +2327,44 @@ class XRefer:
 
         return tuple(result)
 
-    def _gather_sorted_function_api_calls(self, func_ea):
+    def _iter_function_api_calls(self, func_ea: int) -> List[ApiCall]:
+        """Build ApiCall records for direct API calls of a function (unsorted)."""
         if func_ea not in self.api_trace_data:
             return []
-        _should_colorize = False
-        if 'ida' == self._backend.name:
-            import ida_lines
-            _should_colorize = True
-
-        function_api_calls = []
+        records: List[ApiCall] = []
         for api_name, api_calls in self.api_trace_data[func_ea].items():
-            api_name_colorized = api_name_clean = api_name.split('.')[1]
-            if _should_colorize:
-                api_name_colorized = ida_lines.COLSTR(api_name.split('.')[1], ida_lines.SCOLOR_IMPNAME)
-
             for call in api_calls:
-                call_addr_colorized = call_addr_clean = f'0x{call["call_addr"]:x}'
-                if _should_colorize:
-                    call_addr_colorized = ida_lines.COLSTR(f'0x{call["call_addr"]:x}', ida_lines.SCOLOR_LIBNAME)
-
-                # We need both colorized for the view and clean for the report
-                function_api_calls.append((
-                    call['index'],
-                    f'{call_addr_colorized}: {api_name_colorized}{call["call_str"]} x {call["count"]}',
-                    # f'{call_addr_clean}: {api_name_clean}{ida_lines.tag_remove(call["call_str"])} x {call["count"]}'
-                    f'{call_addr_clean}: {api_name_clean}{call["call_str"]} x {call["count"]}'
+                records.append(ApiCall(
+                    index=call["index"],
+                    call_addr=call["call_addr"],
+                    api_name=api_name,
+                    call_str=call["call_str"],
+                    count=call["count"],
                 ))
+        return records
 
-        return function_api_calls
+    def gather_sorted_function_api_calls(self, func_ea: int) -> List[ApiCall]:
+        """Direct API calls of a function, sorted by trace index."""
+        records = self._iter_function_api_calls(func_ea)
+        records.sort(key=lambda r: r.index)
+        return records
 
-    def gather_sorted_function_api_calls(self, func_ea):
-        """
-        Gather and sort all "call_str" for direct API calls of a given function.
+    def gather_sorted_path_api_calls(self, func_ea: int) -> List[ApiCall]:
+        """Direct + indirect API calls reachable from a function, sorted by trace index."""
+        records = self._iter_function_api_calls(func_ea)
+        indirect = self.global_xrefs.get(func_ea, {}).get(self.INDIRECT_XREFS, {}).get("api_trace", set())
+        for indirect_func_ea in indirect:
+            records.extend(self._iter_function_api_calls(indirect_func_ea))
+        records.sort(key=lambda r: r.index)
+        return records
 
-        :param func_ea: The address of the function
-        :return: A list of sorted "call_str" for direct API calls
-        """
-        function_api_calls = self._gather_sorted_function_api_calls(func_ea)
-        function_api_calls.sort(key=itemgetter(0))
-        return [call[1] for call in function_api_calls]
-
-    def gather_sorted_path_api_calls(self, func_ea):
-        """
-        Gather and sort all "call_str" for indirect API calls of a given function.
-
-        :param func_ea: The address of the function
-        :return: A list of sorted "call_str" for indirect API calls
-        """
-        path_api_calls = []
-
-        # Get all functions called indirectly by func_ea
-        indirect_xrefs = self.global_xrefs.get(func_ea, {}).get(self.INDIRECT_XREFS, {})
-        indirect_func_addresses = indirect_xrefs.get("api_trace", set())
-
-        # Gather API calls from these indirect functions
-        for indirect_func_ea in indirect_func_addresses:
-            if indirect_func_ea in self.api_trace_data:
-                for api_name, api_calls in self.api_trace_data[indirect_func_ea].items():
-                    # TODO(rand0m): This is formatting. Should be in gui/. Refactoring the entire code is needed. No time for this now.
-                    # api_name = ida_lines.COLSTR(api_name.split(".")[1], ida_lines.SCOLOR_IMPNAME)
-                    api_name = api_name.split(".")[1]
-
-                    for call in api_calls:
-                        # call_addr = ida_lines.COLSTR(f"0x{call['call_addr']:x}", ida_lines.SCOLOR_LIBNAME)
-                        call_addr = f"0x{call['call_addr']:x}"
-                        path_api_calls.append((call["index"], f"{call_addr}: {api_name}{call['call_str']} x {call['count']}"))
-
-        function_api_calls = self._gather_sorted_function_api_calls(func_ea)
-        # We only need the colorized version for the view
-        path_api_calls.extend([(call[0], call[1]) for call in function_api_calls])
-        path_api_calls.sort(key=itemgetter(0))
-        return [call[1] for call in path_api_calls]
-
-    def gather_sorted_full_api_calls(self):
-        all_calls = []
-
-        # Iterate through all functions and their API calls
-        for func_calls in self.api_trace_data.values():
-            for api_name, api_calls in func_calls.items():
-                # TODO(rand0m): This is formatting. Should be in gui/. Refactoring the entire code is needed. No time for this now.
-                # api_name = ida_lines.COLSTR(api_name.split(".")[1], ida_lines.SCOLOR_IMPNAME)
-                api_name = api_name.split(".")[1]
-
-                for call in api_calls:
-                    # call_addr = ida_lines.COLSTR(f"0x{call['call_addr']:x}", ida_lines.SCOLOR_LIBNAME)
-                    call_addr = f"0x{call['call_addr']:x}"
-                    all_calls.append((call["index"], f"{call_addr}: {api_name}{call['call_str']} x {call['count']}"))
-
-        # Sort the list based on the index
-        all_calls.sort(key=itemgetter(0))
-        return [call[1] for call in all_calls]
+    def gather_sorted_full_api_calls(self) -> List[ApiCall]:
+        """Every API call across all functions, sorted by trace index."""
+        records: List[ApiCall] = []
+        for func_ea in self.api_trace_data:
+            records.extend(self._iter_function_api_calls(func_ea))
+        records.sort(key=lambda r: r.index)
+        return records
 
     def _has_direct_calls(self, func_ea: int, api_name: str) -> bool:
         """Check if a function has direct calls for a specific API."""
@@ -3193,39 +3128,13 @@ class XRefer:
         # Convert sets to sorted lists for stable output
         return {key: sorted(value) for key, value in artifacts.items()}
 
-    def get_api_trace_for_cluster_for_html_report(self, cluster: "FunctionalCluster") -> str:
-        """Aggregates and sorts all API trace calls for a cluster, formatted for the HTML report without addresses."""
-        all_calls = []
+    def get_api_trace_records_for_cluster(self, cluster: "FunctionalCluster") -> List[ApiCall]:
+        """All API call records for a cluster's nodes, sorted by trace index."""
+        records: List[ApiCall] = []
         for func_ea in cluster.nodes:
-            calls_with_index = self._gather_sorted_function_api_calls(func_ea)
-            all_calls.extend(calls_with_index)
-
-        all_calls.sort(key=itemgetter(0))
-
-        # For each call, take the clean string (call[2]), split it at the first colon, and take the second part.
-        report_lines = []
-        for call in all_calls:
-            parts = call[2].split(': ', 1)
-            if len(parts) > 1:
-                report_lines.append(parts[1])
-            else:
-                report_lines.append(call[2]) # Fallback
-
-        return "\n".join(report_lines)
-
-    def get_api_trace_for_cluster(self, cluster: "FunctionalCluster") -> str:
-        """Aggregates and sorts all API trace calls for a cluster."""
-        all_calls = []
-        for func_ea in cluster.nodes:
-            # _gather_sorted_function_api_calls returns (index, colorized_str, clean_str)
-            calls_with_index = self._gather_sorted_function_api_calls(func_ea)
-            all_calls.extend(calls_with_index)
-
-        # Sort all collected calls by their original index
-        all_calls.sort(key=itemgetter(0))
-
-        # Return as a single newline-separated string, using the clean version
-        return "\n".join([call[2] for call in all_calls])
+            records.extend(self._iter_function_api_calls(func_ea))
+        records.sort(key=lambda r: r.index)
+        return records
 
     def generate_report_data(self) -> Dict[str, Any]:
         """Builds the complete data dictionary for the HTML report."""
@@ -3244,12 +3153,16 @@ class XRefer:
             # Drop empty categories to keep report payload lean
             artifacts_dict = {category: items for category, items in artifacts_dict.items() if items}
 
+            api_trace_lines = [
+                f"{r.api_name.split('.')[-1]}{r.call_str} x {r.count}"
+                for r in self.get_api_trace_records_for_cluster(cluster)
+            ]
             node_data = {
                 "key": cluster_id,
                 "label": f"cluster.id.{cluster.id_str}\\n{analysis.get('label') if isinstance(analysis, dict) else analysis.label}",
                 "description": analysis.get('description') if isinstance(analysis, dict) else analysis.description,
                 "artifacts": artifacts_dict,
-                "apiTrace": self.get_api_trace_for_cluster_for_html_report(cluster),
+                "apiTrace": "\n".join(api_trace_lines),
                 "isLibrary": cluster.is_library
             }
             if parent_key is not None:

--- a/plugins/xrefer/core/analyzer.py
+++ b/plugins/xrefer/core/analyzer.py
@@ -2721,10 +2721,10 @@ class XRefer:
         _WARNING_MSG = f"Missing required analysis files: {missing_files}. If you want to suppress this check, enable 'suppress_notifications' in settings ({self.settings_manager.settings_file})."
         if self._backend.name == "ida":
             try:
-                from PyQt5.QtWidgets import QApplication, QDialog
+                from qtpy.QtWidgets import QApplication, QDialog
             except ImportError as exc:
-                log(f"{_WARNING_MSG} PyQt5 is not available; running in headless mode.")
-                raise EnvironmentError(f"{_WARNING_MSG} PyQt5 is required to prompt for missing files. Enable 'suppress_notifications' to bypass this check.") from exc
+                log(f"{_WARNING_MSG} Qt bindings are not available; running in headless mode.")
+                raise EnvironmentError(f"{_WARNING_MSG} A Qt binding (PyQt5/PySide6) is required to prompt for missing files. Enable 'suppress_notifications' to bypass this check.") from exc
             if not QApplication.instance():
                 log(f"{_WARNING_MSG} No active QApplication; running in headless mode.")
                 raise EnvironmentError(f"{_WARNING_MSG} This run is headless. Enable 'suppress_notifications' to bypass this check.")

--- a/plugins/xrefer/gui/action_handlers.py
+++ b/plugins/xrefer/gui/action_handlers.py
@@ -18,7 +18,7 @@ from typing import Any
 import ida_funcs
 import idaapi
 import idc
-from PyQt5 import QtCore, QtGui, QtWidgets
+from qtpy import QtCore, QtGui, QtWidgets
 
 from xrefer.gui.helpers import dump_indirect_calls, handle_entrypoint_selection, log
 from xrefer.gui.settings import XReferSettingsDialog

--- a/plugins/xrefer/gui/action_handlers.py
+++ b/plugins/xrefer/gui/action_handlers.py
@@ -730,28 +730,18 @@ class DumpIndirectCallsHandler(idaapi.action_handler_t):
 
 class ShowWindowHandler(idaapi.action_handler_t):
     def activate(self, ctx: Any) -> bool:
-        """
-        Handle show window action.
+        """Show the XRefer window, rebuilding the view from scratch.
+
+        ``view.create()`` calls ``view.cleanup()`` first, which already
+        tears down any prior dock widget, qt widget, event filters, etc.
+        Don't reach into the view's internal Qt state from here.
         """
         from xrefer.plugin import plugin_instance
 
-        # Create a fresh view if needed, otherwise reuse existing
         if plugin_instance.xrefer_view:
-            # Clear old dock widget if it exists
-            if hasattr(plugin_instance.xrefer_view, "dock_widget"):
-                plugin_instance.xrefer_view.dock_widget.setWidget(None)
-                plugin_instance.xrefer_view.dock_widget.deleteLater()
-                delattr(plugin_instance.xrefer_view, "dock_widget")
-
-            # Show and update
             plugin_instance.xrefer_view.create()
-
-        from xrefer.plugin import plugin_instance
-
-        if plugin_instance.xrefer_view:
             return idaapi.AST_ENABLE_ALWAYS
-        else:
-            return idaapi.AST_DISABLE
+        return idaapi.AST_DISABLE
 
     def update(self, ctx: Any) -> int:
         """

--- a/plugins/xrefer/gui/helpers.py
+++ b/plugins/xrefer/gui/helpers.py
@@ -933,53 +933,51 @@ def create_cluster_relationship_graph(clusters: List["FunctionalCluster"], analy
             graph.add_edge(source, target)
             return True
 
-        # Process multiple clusters case
-        for cluster in clusters:
-            cluster_id = f"cluster.id.{cluster.id:04d}"
+        # Recursively process clusters so subclusters at any depth are added
+        # to the graph (the table view in create_cluster_rows already recurses).
+        # Without this, only top-level clusters and their direct children show up,
+        # and any deeper subcluster is silently dropped.
+        def _process(cluster, parent_text=None):
             if cluster.id in merged_nodes:
-                continue  # Skip merged nodes
+                return  # Skip merged nodes
 
-            # Get cluster data
             cluster_data = find_cluster_analysis(analysis, cluster.id)
             if not cluster_data:
-                continue
+                return
 
+            cluster_id = f"cluster.id.{cluster.id:04d}"
             label = cluster_data.get("label", "").strip()
             if not add_valid_node(cluster_id, label):
-                continue
+                return
 
             node_text = f"{cluster_id}\n{label}" if label else cluster_id
 
-            # Process relationships respecting merges
-            if cluster.parent_cluster_id:
-                parent_data = find_cluster_analysis(analysis, cluster.parent_cluster_id)
-                if parent_data:
-                    parent_id = f"cluster.id.{cluster.parent_cluster_id:04d}"
-                    parent_label = parent_data.get("label", "").strip()
-                    if add_valid_node(parent_id, parent_label):
-                        parent_text = f"{parent_id}\n{parent_label}" if parent_label else parent_id
-                        add_valid_edge(parent_text, node_text)
+            # Edge from the (already-added) parent in the recursion chain.
+            if parent_text:
+                add_valid_edge(parent_text, node_text)
 
-            # Handle subclusters
+            # Subclusters — recurse so multi-level hierarchies are fully drawn.
             for subcluster in cluster.subclusters:
-                sub_data = find_cluster_analysis(analysis, subcluster.id)
-                if sub_data and subcluster.id not in merged_nodes:
-                    sub_id = f"cluster.id.{subcluster.id:04d}"
-                    sub_label = sub_data.get("label", "").strip()
-                    if add_valid_node(sub_id, sub_label):
-                        sub_text = f"{sub_id}\n{sub_label}" if sub_label else sub_id
-                        add_valid_edge(node_text, sub_text)
+                _process(subcluster, parent_text=node_text)
 
-            # Handle cluster references
+            # Cluster references — these point at clusters whose root replaced
+            # one of our nodes during decomposition. Add the referenced cluster
+            # as a node and an edge from us to it (no recursion: the referenced
+            # cluster is already reachable via its own subcluster chain).
             for _, ref_id in cluster.cluster_refs.items():
-                if ref_id not in merged_nodes:  # Skip refs to merged nodes
-                    ref_data = find_cluster_analysis(analysis, ref_id)
-                    if ref_data:
-                        ref_id_str = f"cluster.id.{ref_id:04d}"
-                        ref_label = ref_data.get("label", "").strip()
-                        if add_valid_node(ref_id_str, ref_label):
-                            ref_text = f"{ref_id_str}\n{ref_label}" if ref_label else ref_id_str
-                            add_valid_edge(node_text, ref_text)
+                if ref_id in merged_nodes:
+                    continue
+                ref_data = find_cluster_analysis(analysis, ref_id)
+                if not ref_data:
+                    continue
+                ref_id_str = f"cluster.id.{ref_id:04d}"
+                ref_label = ref_data.get("label", "").strip()
+                if add_valid_node(ref_id_str, ref_label):
+                    ref_text = f"{ref_id_str}\n{ref_label}" if ref_label else ref_id_str
+                    add_valid_edge(node_text, ref_text)
+
+        for cluster in clusters:
+            _process(cluster, parent_text=None)
 
         return graph
 
@@ -1112,9 +1110,13 @@ def create_cluster_rows(cluster, analysis, column_width, paths):
     # Process nodes and description
     nodes = sorted(cluster.nodes)
     if nodes:
-        # First row with cluster info and first node
+        # First row with cluster info and first node.
+        # cluster.nodes contains xrefer.backend.base.Address instances (an int
+        # subclass from the gsoc_2025 backend abstraction). IDA 9.3's SWIG
+        # bindings strict-typecheck `ea_t` and reject int subclasses, so we
+        # explicitly cast to plain int when crossing into IDA's C API.
         first_node = nodes[0]
-        func_name = idc.get_func_name(first_node)
+        func_name = idc.get_func_name(int(first_node))
         if len(func_name) > 13:
             func_name = f"{func_name[:11]}.."
         func_name = ida_lines.COLSTR(func_name, ida_lines.SCOLOR_CODNAME)
@@ -1135,7 +1137,7 @@ def create_cluster_rows(cluster, analysis, column_width, paths):
             # If we have more nodes, show the next node with the separator line
             if remaining_nodes:
                 node = remaining_nodes[0]
-                func_name = idc.get_func_name(node)
+                func_name = idc.get_func_name(int(node))
                 if len(func_name) > 13:
                     func_name = f"{func_name[:11]}.."
                 func_name = ida_lines.COLSTR(func_name, ida_lines.SCOLOR_CODNAME)
@@ -1178,7 +1180,7 @@ def create_cluster_rows(cluster, analysis, column_width, paths):
             right_col = ""
             if i < len(remaining_nodes):
                 node = remaining_nodes[i]
-                func_name = idc.get_func_name(node)
+                func_name = idc.get_func_name(int(node))
                 if len(func_name) > 13:
                     func_name = f"{func_name[:11]}.."
                 func_name = ida_lines.COLSTR(func_name, ida_lines.SCOLOR_CODNAME)

--- a/plugins/xrefer/gui/helpers.py
+++ b/plugins/xrefer/gui/helpers.py
@@ -36,6 +36,44 @@ from tabulate import tabulate
 from xrefer.core.analyzer import ApiCall
 
 
+def qt_object_alive(obj) -> bool:
+    """Return True if ``obj`` is a Python wrapper around a still-live Qt C++ object.
+
+    Qt+Python lifetime: when the underlying C++ object is destroyed, the
+    Python wrapper survives but any method call on it raises
+    ``RuntimeError: Internal C++ object … already deleted``. Use this check
+    before touching any cached widget reference.
+
+    Probes the active binding's introspection module (``shiboken6`` for
+    PySide6, ``shiboken2`` for PySide2, ``sip`` for PyQt5/6). If none is
+    importable we err on the side of "alive" — caller still gets a
+    ``RuntimeError`` if the access turns out to be invalid.
+    """
+    if obj is None:
+        return False
+    try:
+        from shiboken6 import isValid
+        return bool(isValid(obj))
+    except ImportError:
+        pass
+    try:
+        from shiboken2 import isValid
+        return bool(isValid(obj))
+    except ImportError:
+        pass
+    try:
+        from PyQt5 import sip
+        return not sip.isdeleted(obj)
+    except (ImportError, TypeError):
+        pass
+    try:
+        from PyQt6 import sip
+        return not sip.isdeleted(obj)
+    except (ImportError, TypeError):
+        pass
+    return True
+
+
 def twidget_to_qt(twidget):
     """Convert an IDA TWidget* into a QWidget of the active Qt binding.
 

--- a/plugins/xrefer/gui/helpers.py
+++ b/plugins/xrefer/gui/helpers.py
@@ -30,10 +30,37 @@ import idaapi
 import idc
 import ida_idaapi
 import networkx as nx
-from PyQt5 import QtCore, QtWidgets
+from qtpy import QtCore, QtWidgets
 from tabulate import tabulate
 
 from xrefer.core.analyzer import ApiCall
+
+
+def twidget_to_qt(twidget):
+    """Convert an IDA TWidget* into a QWidget of the active Qt binding.
+
+    IDA 9.3 ships two bridge implementations on PluginForm:
+
+    - ``TWidgetToQtPythonWidget`` (canonical name; aliased as
+      ``TWidgetToPyQtWidget`` and ``FormToPyQtWidget``): PySide6-native via
+      ``shiboken6.Shiboken.wrapInstance``. Returns a PySide6 widget regardless
+      of whether the PyQt5 shim is active. Reads no module-level state. This
+      is the function we always want.
+    - ``TWidgetToPySideWidget`` (aliased as ``FormToPySideWidget``): broken in
+      9.3 — it dereferences ``__main__.QtGui.QWidget``, which is undefined for
+      vanilla PySide6 (``QWidget`` lives in ``QtWidgets``). It looks vestigial
+      from the Qt4 era and cannot be rescued by planting modules. Do not call.
+
+    Older IDA (8.x) exposes only ``TWidgetToPyQtWidget``; under those versions
+    the return type is a PyQt5 widget. Either way, the canonical lookup below
+    resolves to the right implementation.
+    """
+    plugin_form = idaapi.PluginForm
+    bridge = (
+        getattr(plugin_form, "TWidgetToQtPythonWidget", None)
+        or plugin_form.TWidgetToPyQtWidget
+    )
+    return bridge(twidget)
 
 
 class FocusEventFilter(QtCore.QObject):

--- a/plugins/xrefer/gui/helpers.py
+++ b/plugins/xrefer/gui/helpers.py
@@ -33,6 +33,8 @@ import networkx as nx
 from PyQt5 import QtCore, QtWidgets
 from tabulate import tabulate
 
+from xrefer.core.analyzer import ApiCall
+
 
 class FocusEventFilter(QtCore.QObject):
     """
@@ -618,6 +620,13 @@ def colorize_api_call(input_string: str) -> str:
         i += 1
 
     return ida_lines.COLSTR("".join(result), ida_lines.SCOLOR_DEMNAME)
+
+
+def format_api_call_for_ida(rec: ApiCall) -> str:
+    """Render an ApiCall record for the IDA custom-viewer panel with full color decoration."""
+    addr = ida_lines.COLSTR(f"0x{rec.call_addr:x}", ida_lines.SCOLOR_LIBNAME)
+    name = ida_lines.COLSTR(rec.api_name.split(".")[-1], ida_lines.SCOLOR_IMPNAME)
+    return f"{addr}: {name}{colorize_api_call(rec.call_str)} x {rec.count}"
 
 
 def create_function_rows_for_interesting_artifacts(func_ea: int, artifacts: List[Tuple], xrefer_obj) -> List[List[str]]:

--- a/plugins/xrefer/gui/settings.py
+++ b/plugins/xrefer/gui/settings.py
@@ -43,6 +43,66 @@ FILE_FILTERS = {
     "default": "All Files (*.*)",
 }
 
+
+# Compatibility criteria for the LLM model dropdown. Models must satisfy ALL:
+#   - chat-completion API (DSPy uses chat endpoints)
+#   - >=1M input tokens (cluster prompts get large on real binaries)
+#   - >=16k output tokens (matches the codebase's per-provider max_tokens floor)
+#   - structured output capability (DSPy Predict + Pydantic OutputField needs
+#     either JSON-schema response_format or function-calling fallback)
+# Restricted to direct-API providers users typically have keys for, to avoid
+# 100+ regional/gateway duplicates from Bedrock/Azure/OpenRouter/etc.
+# Anthropic is excluded: litellm reports max_input_tokens=1_000_000 for Claude 4.x
+# entries, but that 1M is beta-gated (requires the anthropic-beta:context-1m-...
+# header AND API tier 4+). The default for those models is 200k, so listing them
+# in a curated dropdown would over-promise and fail at runtime on real prompts.
+_LLM_MIN_INPUT_TOKENS = 1_000_000
+_LLM_MIN_OUTPUT_TOKENS = 16_000
+_LLM_ALLOWED_PROVIDERS = frozenset({"openai", "gemini", "xai"})
+
+
+def _curated_llm_models() -> List[str]:
+    """Return models from litellm.model_cost that meet XRefer's workload requirements.
+
+    Returns an empty list if litellm is unavailable — the caller renders an empty
+    dropdown, which is the right signal since processor.py also imports litellm.
+    """
+    try:
+        import litellm
+        cost_table = litellm.model_cost
+    except (ImportError, AttributeError):
+        return []
+
+    seen: set = set()
+    out: List[str] = []
+    for name, info in cost_table.items():
+        if not isinstance(info, dict):
+            continue
+        if info.get("mode") != "chat":
+            continue
+        provider = info.get("litellm_provider")
+        if provider not in _LLM_ALLOWED_PROVIDERS:
+            continue
+        try:
+            max_in = int(info.get("max_input_tokens") or 0)
+            max_out = int(info.get("max_output_tokens") or 0)
+        except (TypeError, ValueError):
+            continue
+        if max_in < _LLM_MIN_INPUT_TOKENS or max_out < _LLM_MIN_OUTPUT_TOKENS:
+            continue
+        if not (info.get("supports_response_schema") or info.get("supports_function_calling")):
+            continue
+        if name.startswith("ft:"):  # fine-tuned templates, not callable model ids
+            continue
+        if "/" not in name:  # normalize bare names to provider/model form
+            name = f"{provider}/{name}"
+        if name in seen:
+            continue
+        seen.add(name)
+        out.append(name)
+    return sorted(out)
+
+
 class CustomTabWidget(QTabWidget):
     """
     Customized QTabWidget with equal width tabs.
@@ -452,16 +512,7 @@ class XReferSettingsDialog(QDialog):
         llm_grid = QGridLayout()
 
         self.llm_model_combo = QComboBox()
-        self.llm_model_combo.addItems([
-            "gemini/gemini-2.5-pro",
-            "gemini/gemini-2.5-pro-preview-06-05",
-            "gemini/gemini-2.5-pro-preview-05-06",
-            "gemini/gemini-2.5-flash-preview-05-20",
-            "gemini/gemini-flash-latest",
-            "openai/gpt-5",
-            "openai/gpt-5-mini",
-            "openai/gpt-5-nano",
-        ])
+        self.llm_model_combo.addItems(_curated_llm_models())
         self.llm_model_combo.setEditable(True)
         self.llm_model_combo.setInsertPolicy(QComboBox.NoInsert)
         self.llm_model_combo.setCurrentText(self.settings.get("llm_model_id", ""))

--- a/plugins/xrefer/gui/settings.py
+++ b/plugins/xrefer/gui/settings.py
@@ -17,10 +17,10 @@ import os
 import re
 from typing import TYPE_CHECKING, Dict, List
 
-from PyQt5.QtCore import Qt
-from PyQt5.QtGui import QFont, QFontMetrics
-from PyQt5.QtWidgets import (QApplication, QCheckBox, QComboBox, QDialog, QFileDialog, QFrame, QGridLayout, QGroupBox, QHBoxLayout, QInputDialog, QLabel, QLineEdit, QListWidget, QMessageBox,
-                             QPushButton, QScrollArea, QSizePolicy, QSpinBox, QTabWidget, QVBoxLayout, QWidget)
+from qtpy.QtCore import Qt
+from qtpy.QtGui import QFont, QFontMetrics
+from qtpy.QtWidgets import (QApplication, QCheckBox, QComboBox, QDialog, QFileDialog, QFrame, QGridLayout, QGroupBox, QHBoxLayout, QInputDialog, QLabel, QLineEdit, QListWidget, QMessageBox,
+                            QPushButton, QScrollArea, QSizePolicy, QSpinBox, QTabWidget, QVBoxLayout, QWidget)
 
 from xrefer.core.settings import XReferSettingsManager
 

--- a/plugins/xrefer/gui/view.py
+++ b/plugins/xrefer/gui/view.py
@@ -42,7 +42,7 @@ from xrefer.gui.action_handlers import ArtifactAnalysisHandler, ClusterEverythin
 from xrefer.gui.help import ContextHelp
 from xrefer.gui.helpers import (CollapseEventFilter, CollapseIndicator, FocusEventFilter, KeyEventFilter, colorize_api_call, create_cluster_relationship_graph,
                                 create_colored_table_from_cols, create_interesting_artifacts_table, create_xrefs_table_colored, draw_cluster_hierarchy, find_cluster_analysis,
-                                format_api_call_for_ida, help_text, log, patch_asciinet, prepare_interesting_artifacts_table_rows, register_popup_action,
+                                format_api_call_for_ida, help_text, log, patch_asciinet, prepare_interesting_artifacts_table_rows, qt_object_alive, register_popup_action,
                                 set_focus_to_code, set_xref_coverage_color, twidget_to_qt)
 from xrefer.gui.legacy.shim import format_ribbon
 from xrefer.gui.state_machine import XReferStateMachine
@@ -139,6 +139,12 @@ class XReferView(idaapi.simplecustviewer_t):
         self.widget = None
         self.qt_widget = None
         self.dock_widget = None
+        # Optional Qt children. Always present as attributes (set to None when
+        # absent) so cleanup, deferred callbacks, and resize handlers can rely
+        # on a uniform `is not None` / qt_object_alive check.
+        self.collapse_indicator = None
+        self.resize_filter = None
+        self.close_handler = None
         self.last_non_graph_width = None
         self.in_graph_view = False
         self._is_collapsed = False
@@ -154,38 +160,61 @@ class XReferView(idaapi.simplecustviewer_t):
         """
         self.cleanup()
 
+    def _connect_destroyed_handler(self, widget) -> None:
+        """Connect a destroyed-signal slot bound to *this specific* widget.
+
+        Why a closure: the destroyed signal fires asynchronously, after Qt
+        processes ``deleteLater``. By that time, ``self.qt_widget`` may already
+        have been reassigned to a *new* widget (recreate path). An unbound slot
+        that does ``self.qt_widget = None`` would invalidate the new widget by
+        mistake. Capturing ``widget`` in the closure means the slot only nils
+        our reference when the destroyed widget IS still the one we hold.
+        """
+        def handler(*_args):
+            if self.qt_widget is widget:
+                self.qt_widget = None
+                self.focus_event_filter = None
+                self.event_filter = None
+        widget.destroyed.connect(handler)
+
     def cleanup(self):
-        """Clean up resources and event handlers."""
+        """Clean up resources and event handlers, tolerant of partial teardown.
+
+        IDA may have already destroyed the underlying widget by the time it
+        invokes our cleanup, so each Qt access is guarded by a liveness check.
+        Each block runs independently — a stale reference in one place doesn't
+        prevent the rest of the cleanup from completing. Attributes are set to
+        ``None`` rather than ``delattr``-ed so deferred callbacks see a stable
+        attribute and bail out via ``qt_object_alive(self.X)``.
+        """
         try:
-            if hasattr(self, "qt_widget"):
-                if self.focus_event_filter:
+            if qt_object_alive(self.qt_widget):
+                if self.focus_event_filter is not None:
                     self.qt_widget.removeEventFilter(self.focus_event_filter)
-                if self.event_filter:
+                if self.event_filter is not None:
                     self.qt_widget.removeEventFilter(self.event_filter)
 
             self.focus_event_filter = None
             self.event_filter = None
 
-            if hasattr(self, "collapse_indicator"):
+            if qt_object_alive(self.collapse_indicator):
                 self.collapse_indicator.hide()
                 self.collapse_indicator.setParent(None)
                 self.collapse_indicator.deleteLater()
-                delattr(self, "collapse_indicator")
+            self.collapse_indicator = None
 
-            if hasattr(self, "resize_filter"):
-                delattr(self, "resize_filter")
+            self.resize_filter = None
 
-            if hasattr(self, "dock_widget"):
-                if self.dock_widget:
-                    self.dock_widget.setWidget(None)
-                    self.dock_widget.close()
-                    self.dock_widget.deleteLater()
-                delattr(self, "dock_widget")
+            if qt_object_alive(self.dock_widget):
+                self.dock_widget.setWidget(None)
+                self.dock_widget.close()
+                self.dock_widget.deleteLater()
+            self.dock_widget = None
 
-            if self.qt_widget:
+            if qt_object_alive(self.qt_widget):
                 self.qt_widget.setParent(None)
                 self.qt_widget.deleteLater()
-                self.qt_widget = None
+            self.qt_widget = None
 
         except Exception as e:
             log(f"[-] Error during cleanup: {str(e)}")
@@ -228,6 +257,10 @@ class XReferView(idaapi.simplecustviewer_t):
             if not self.qt_widget:
                 log("Failed to get Qt widget")
                 return
+
+            # Clear our cached references when Qt destroys *this specific*
+            # widget, so cleanup/show paths don't dereference stale wrappers.
+            self._connect_destroyed_handler(self.qt_widget)
 
             self.qt_widget.setFocusPolicy(QtCore.Qt.StrongFocus)
 
@@ -275,7 +308,7 @@ class XReferView(idaapi.simplecustviewer_t):
                 return
 
             # Ensure event filters are properly installed
-            if self.qt_widget:
+            if qt_object_alive(self.qt_widget):
                 if not self.focus_event_filter:
                     self.focus_event_filter = FocusEventFilter(self)
                 if not self.event_filter:
@@ -294,7 +327,7 @@ class XReferView(idaapi.simplecustviewer_t):
                 self.update(True)
 
             # Force a repaint
-            if self.qt_widget:
+            if qt_object_alive(self.qt_widget):
                 self.qt_widget.repaint()
         except Exception as e:
             log(f"[-] Error showing custom window: {str(e)}")
@@ -303,8 +336,15 @@ class XReferView(idaapi.simplecustviewer_t):
     def Show(self, *args) -> None:
         """
         Override Show to use our custom window handling.
+
+        If the underlying Qt widget was destroyed (e.g. user closed the dock),
+        rebuild from scratch via ``create()``; otherwise just bring the existing
+        window forward.
         """
-        self.show_custom_window()
+        if not qt_object_alive(self.qt_widget):
+            self.create()
+        else:
+            self.show_custom_window()
 
     def setup_hooks(self):
         """
@@ -370,7 +410,7 @@ class XReferView(idaapi.simplecustviewer_t):
 
     def position_window(self) -> None:
         """Position and configure the window docking."""
-        if not hasattr(self, "qt_widget") or not self.qt_widget:
+        if not qt_object_alive(self.qt_widget):
             log("Qt widget not initialized")
             return
 
@@ -387,7 +427,7 @@ class XReferView(idaapi.simplecustviewer_t):
 
         try:
             # Create new dock widget if it doesn't exist
-            if not hasattr(self, "dock_widget") or not self.dock_widget:
+            if not qt_object_alive(self.dock_widget):
                 self.dock_widget = QtWidgets.QDockWidget(self.title, main_window)
                 self.dock_widget.setObjectName("XReferDockWidget")
 
@@ -426,9 +466,10 @@ class XReferView(idaapi.simplecustviewer_t):
 
                 # Handle close event
                 def handle_close(event):
-                    if hasattr(self, "collapse_indicator"):
+                    if qt_object_alive(self.collapse_indicator):
                         self.collapse_indicator.hide()
-                    self.dock_widget.hide()
+                    if qt_object_alive(self.dock_widget):
+                        self.dock_widget.hide()
                     event.ignore()
 
                 self.close_handler = handle_close
@@ -440,26 +481,47 @@ class XReferView(idaapi.simplecustviewer_t):
                 # Show dock widget and ensure indicator is visible
                 self.dock_widget.show()
 
-                # Use multiple delayed repositioning attempts to ensure proper placement
-                QtCore.QTimer.singleShot(50, lambda: (self.collapse_indicator.show(), self.collapse_indicator.reposition()))
-                QtCore.QTimer.singleShot(100, lambda: (self.collapse_indicator.reposition(), self.collapse_indicator.raise_()))
-                QtCore.QTimer.singleShot(200, self.collapse_indicator.reposition)
+                # Schedule deferred repositioning. The lambdas may fire after
+                # the dock has been closed/destroyed — guard each access via
+                # the named helpers below.
+                QtCore.QTimer.singleShot(50, self._show_and_reposition_indicator)
+                QtCore.QTimer.singleShot(100, self._reposition_and_raise_indicator)
+                QtCore.QTimer.singleShot(200, self._reposition_indicator)
 
             else:
                 # If dock widget exists but is hidden, show it
                 self.dock_widget.show()
-                if hasattr(self, "collapse_indicator"):
-                    QtCore.QTimer.singleShot(50, lambda: (self.collapse_indicator.show(), self.collapse_indicator.reposition()))
-                    QtCore.QTimer.singleShot(100, lambda: (self.collapse_indicator.reposition(), self.collapse_indicator.raise_()))
+                QtCore.QTimer.singleShot(50, self._show_and_reposition_indicator)
+                QtCore.QTimer.singleShot(100, self._reposition_and_raise_indicator)
 
         except Exception as e:
             log(f"[-] Error creating dock widget: {str(e)}")
             self.cleanup()
             return
 
+    # --- defensive helpers for deferred QTimer callbacks ---
+    # Each runs after a delay; cleanup may have nilled the indicator in the
+    # meantime. ``qt_object_alive`` returns False both for None and for a
+    # wrapper whose C++ object has been deleted, so all three are safe no-ops
+    # against a gone widget.
+
+    def _show_and_reposition_indicator(self) -> None:
+        if qt_object_alive(self.collapse_indicator):
+            self.collapse_indicator.show()
+            self.collapse_indicator.reposition()
+
+    def _reposition_and_raise_indicator(self) -> None:
+        if qt_object_alive(self.collapse_indicator):
+            self.collapse_indicator.reposition()
+            self.collapse_indicator.raise_()
+
+    def _reposition_indicator(self) -> None:
+        if qt_object_alive(self.collapse_indicator):
+            self.collapse_indicator.reposition()
+
     def handle_visibility_changed(self, visible):
         """Handle dock widget visibility changes."""
-        if visible and self.qt_widget:
+        if visible and qt_object_alive(self.qt_widget):
             # Reinstall event filters if needed
             if not self.focus_event_filter:
                 self.focus_event_filter = FocusEventFilter(self)
@@ -470,33 +532,22 @@ class XReferView(idaapi.simplecustviewer_t):
             self.qt_widget.installEventFilter(self.event_filter)
 
             # Show/reposition collapse indicator
-            if hasattr(self, "collapse_indicator"):
+            if qt_object_alive(self.collapse_indicator):
                 self.collapse_indicator.show()
                 self.collapse_indicator.reposition()
 
             self.update(True)
-        elif not visible and hasattr(self, "collapse_indicator"):
+        elif not visible and qt_object_alive(self.collapse_indicator):
             self.collapse_indicator.hide()
 
-    def handle_dock_close(self, event):
-        """
-        Handle dock widget close event to properly clean up resources.
-        """
-        # Clean up the dock widget
-        if hasattr(self, "dock_widget"):
-            self.dock_widget.setWidget(None)
-            self.dock_widget.deleteLater()
-            delattr(self, "dock_widget")
-
-        # Clean up the widget
-        if hasattr(self, "qt_widget"):
-            self.qt_widget.setParent(None)
-            self.qt_widget.deleteLater()
-
-        event.accept()
-
     def reset_size_constraints(self):
-        """Reset size constraints to allow user resizing."""
+        """Reset size constraints to allow user resizing.
+
+        Scheduled via ``QTimer.singleShot`` after creating the dock; may fire
+        after the dock has been closed. Skip silently if the dock is gone.
+        """
+        if not qt_object_alive(self.dock_widget):
+            return
         self.dock_widget.setMinimumWidth(0)
         self.dock_widget.setMaximumWidth(16777215)  # Qt's QWIDGETSIZE_MAX
         self.dock_widget.updateGeometry()
@@ -3202,7 +3253,7 @@ class XReferView(idaapi.simplecustviewer_t):
             return
 
         # Safety check for dock widget
-        if not hasattr(self, "dock_widget") or not self.dock_widget:
+        if not qt_object_alive(self.dock_widget):
             return
 
         # Only resize for specific states
@@ -3232,7 +3283,7 @@ class XReferView(idaapi.simplecustviewer_t):
             self.in_graph_view = False
             return
 
-        if not hasattr(self, "qt_widget") or not self.qt_widget or not hasattr(self, "dock_widget") or not self.dock_widget:
+        if not qt_object_alive(self.qt_widget) or not qt_object_alive(self.dock_widget):
             return
 
         # Store current width before entering graph view if not already in it
@@ -4081,20 +4132,22 @@ class XReferView(idaapi.simplecustviewer_t):
         """
         Get name of table containing current line.
 
-        Searches upward from current line to find enclosing table header.
-
-        Returns:
-            Optional[str]: Name of parent table, or None if not found
+        Searches upward from the line under the mouse to find an enclosing
+        table header. ``GetLineNo(mouse=1)`` returns ``-1`` when the mouse is
+        not over any line — that sentinel is **truthy** in Python, so we must
+        bail out explicitly rather than relying on ``while lineno:``.
         """
-        lineno: int = self.GetLineNo(mouse=1)
-        table_name: Optional[str] = None
+        lineno = self.GetLineNo(mouse=1)
+        if lineno is None or lineno < 0:
+            return None
 
-        while lineno:
-            line, _, _ = self.GetLine(lineno)
-            _table_name: str = line[6:-2].strip()
-            if _table_name in self.table_names:
-                table_name = _table_name
-                break
+        while lineno >= 0:
+            result = self.GetLine(lineno)
+            if not result or result[0] is None:
+                return None
+            line = result[0]
+            candidate = line[6:-2].strip()
+            if candidate in self.table_names:
+                return candidate
             lineno -= 1
-
-        return table_name
+        return None

--- a/plugins/xrefer/gui/view.py
+++ b/plugins/xrefer/gui/view.py
@@ -32,7 +32,7 @@ import idaapi
 import idautils
 import idc
 import networkx as nx
-from PyQt5 import QtCore, QtGui, QtWidgets
+from qtpy import QtCore, QtGui, QtWidgets
 
 from xrefer.core.analyzer import ApiCall, XRefer
 from xrefer.core.helpers import (find_cluster_analysis, get_addr_from_text, is_windows_or_linux, longest_line_length, parse_cluster_id, remove_non_displayable, strip_color_codes,
@@ -43,7 +43,7 @@ from xrefer.gui.help import ContextHelp
 from xrefer.gui.helpers import (CollapseEventFilter, CollapseIndicator, FocusEventFilter, KeyEventFilter, colorize_api_call, create_cluster_relationship_graph,
                                 create_colored_table_from_cols, create_interesting_artifacts_table, create_xrefs_table_colored, draw_cluster_hierarchy, find_cluster_analysis,
                                 format_api_call_for_ida, help_text, log, patch_asciinet, prepare_interesting_artifacts_table_rows, register_popup_action,
-                                set_focus_to_code, set_xref_coverage_color)
+                                set_focus_to_code, set_xref_coverage_color, twidget_to_qt)
 from xrefer.gui.legacy.shim import format_ribbon
 from xrefer.gui.state_machine import XReferStateMachine
 
@@ -224,7 +224,7 @@ class XReferView(idaapi.simplecustviewer_t):
                 log("Failed to get widget")
                 return
 
-            self.qt_widget = idaapi.PluginForm.TWidgetToPyQtWidget(self.widget)
+            self.qt_widget = twidget_to_qt(self.widget)
             if not self.qt_widget:
                 log("Failed to get Qt widget")
                 return

--- a/plugins/xrefer/gui/view.py
+++ b/plugins/xrefer/gui/view.py
@@ -35,7 +35,7 @@ import networkx as nx
 from qtpy import QtCore, QtGui, QtWidgets
 
 from xrefer.core.analyzer import ApiCall, XRefer
-from xrefer.core.helpers import (find_cluster_analysis, get_addr_from_text, is_windows_or_linux, longest_line_length, parse_cluster_id, remove_non_displayable, strip_color_codes,
+from xrefer.core.helpers import (find_cluster_analysis, get_addr_from_text, longest_line_length, parse_cluster_id, remove_non_displayable, strip_color_codes,
                                  wrap_substring_with_string)
 from xrefer.core.settings import XReferSettingsManager
 from xrefer.gui.action_handlers import ArtifactAnalysisHandler, ClusterEverythingHandler, ClusterInterestingFunctionsHandler, CopyInterestingStringsHandler, PeekViewToggleHandler
@@ -129,7 +129,11 @@ class XReferView(idaapi.simplecustviewer_t):
         self.state_machine: XReferStateMachine = XReferStateMachine()
         self.table_index_offset: int = 4  # default state starts from direct xrefs
         self.table_count: int = len(self.table_states)
-        self.indent: str = "        " if is_windows_or_linux() else "    "
+        # 8 spaces aligns expanded-table row content with the heading text that
+        # follows the "----" continuation marker; see draw_function_context_table_heading.
+        # Used to be OS-conditional (4 on macOS, 8 on Win/Linux) which produced
+        # noticeably shallower indentation on Mac. Unified across platforms.
+        self.indent: str = "        "
         self.INDENT: str = "    "  # Standard 4-space indentation
         self.peek_flag: bool = False
         self.last_boundary_scan_results: Optional[str] = None
@@ -3595,7 +3599,11 @@ class XReferView(idaapi.simplecustviewer_t):
         hline: str = ida_lines.COLSTR(fmt % heading_line, ida_lines.SCOLOR_DATNAME)
         self.AddLine(hline)
         heading_line = self.xrefer_obj.table_data[func_ea][table_name]["heading"][1]
-        if is_windows_or_linux() and not table_name.startswith("D"):
+        # Non-direct tables get a "----" continuation marker that visually
+        # extends the dashed line from the "(-)" expansion indicator. Direct
+        # tables stand on their own and don't need it. Used to be OS-gated
+        # (only Win/Linux got the marker); unified across platforms.
+        if not table_name.startswith("D"):
             hline = ida_lines.COLSTR(f"    ----{heading_line}", ida_lines.SCOLOR_DATNAME)
         else:
             hline = ida_lines.COLSTR(f"    {heading_line}", ida_lines.SCOLOR_DATNAME)

--- a/plugins/xrefer/gui/view.py
+++ b/plugins/xrefer/gui/view.py
@@ -34,15 +34,16 @@ import idc
 import networkx as nx
 from PyQt5 import QtCore, QtGui, QtWidgets
 
-from xrefer.core.analyzer import XRefer
+from xrefer.core.analyzer import ApiCall, XRefer
 from xrefer.core.helpers import (find_cluster_analysis, get_addr_from_text, is_windows_or_linux, longest_line_length, parse_cluster_id, remove_non_displayable, strip_color_codes,
                                  wrap_substring_with_string)
 from xrefer.core.settings import XReferSettingsManager
 from xrefer.gui.action_handlers import ArtifactAnalysisHandler, ClusterEverythingHandler, ClusterInterestingFunctionsHandler, CopyInterestingStringsHandler, PeekViewToggleHandler
 from xrefer.gui.help import ContextHelp
-from xrefer.gui.helpers import (CollapseEventFilter, CollapseIndicator, FocusEventFilter, KeyEventFilter, create_cluster_relationship_graph, create_colored_table_from_cols,
-                                create_interesting_artifacts_table, create_xrefs_table_colored, draw_cluster_hierarchy, find_cluster_analysis, help_text, log, patch_asciinet,
-                                prepare_interesting_artifacts_table_rows, register_popup_action, set_focus_to_code, set_xref_coverage_color)
+from xrefer.gui.helpers import (CollapseEventFilter, CollapseIndicator, FocusEventFilter, KeyEventFilter, colorize_api_call, create_cluster_relationship_graph,
+                                create_colored_table_from_cols, create_interesting_artifacts_table, create_xrefs_table_colored, draw_cluster_hierarchy, find_cluster_analysis,
+                                format_api_call_for_ida, help_text, log, patch_asciinet, prepare_interesting_artifacts_table_rows, register_popup_action,
+                                set_focus_to_code, set_xref_coverage_color)
 from xrefer.gui.legacy.shim import format_ribbon
 from xrefer.gui.state_machine import XReferStateMachine
 
@@ -1443,7 +1444,7 @@ class XReferView(idaapi.simplecustviewer_t):
             calls = self.xrefer_obj.get_indirect_calls(api_name, self.func_ea)
 
         for call, count in calls:
-            self.AddLine(f"{indent}{call} x {count}")
+            self.AddLine(f"{indent}{colorize_api_call(call)} x {count}")
 
     def add_expanded_calls(self, line: str) -> bool:
         """
@@ -3372,105 +3373,49 @@ class XReferView(idaapi.simplecustviewer_t):
         exclusions = self.xrefer_obj.settings_manager.load_exclusions()
         return api_suffix in (name.lower() for name in exclusions["apis"])
 
-    def filter_api_calls(self, calls: List[str]) -> List[str]:
-        """
-        Filter API calls based on exclusions settings.
-
-        Removes excluded API calls from the provided list.
-
-        Args:
-            calls (List[str]): List of API call strings to filter
-
-        Returns:
-            List[str]: Filtered list with excluded calls removed
-        """
+    def filter_api_calls(self, calls: List[ApiCall]) -> List[ApiCall]:
+        """Drop API call records whose api_name is on the exclusions list."""
         if not self.xrefer_obj.settings["enable_exclusions"]:
             return calls
+        return [c for c in calls if not self.is_api_excluded(c.api_name)]
 
-        filtered_calls = []
-        for call in calls:
-            # Extract API name from the call string
-            # Format is typically: "0x123456: ApiName(args) = result"
-            try:
-                api_name = call.split(":")[1].strip().split("(")[0].strip()
-                api_name_cleaned = api_name.split('"')[1].strip()[:-1]
+    def _render_trace(self, calls: List[ApiCall], empty_msg: str) -> None:
+        """Shared rendering for the three trace scopes."""
+        self.ClearLines()
+        self.print_ribbon()
 
-                if not self.is_api_excluded(api_name_cleaned):
-                    filtered_calls.append(call)
-            except IndexError:
-                # If we can't parse the call string, include it
-                filtered_calls.append(call)
+        if not calls:
+            self.AddLine(empty_msg)
+            return
 
-        return filtered_calls
+        filtered_calls = self.filter_api_calls(calls)
+        if not filtered_calls:
+            self.AddLine("    ALL API CALLS ARE EXCLUDED")
+            return
+
+        for rec in filtered_calls:
+            self.AddLine(format_api_call_for_ida(rec))
 
     def handle_trace_scope_function(self) -> None:
-        """
-        Handle function-scope trace display.
-
-        Shows API calls made directly from the current function,
-        applying exclusions filtering if enabled.
-        """
-        self.ClearLines()
-        self.print_ribbon()
-        calls = self.xrefer_obj.gather_sorted_function_api_calls(self.func_ea)
-
-        if not calls:
-            self.AddLine("    NO API CALLS FOUND FOR CURRENT FUNCTION")
-            return
-
-        filtered_calls = self.filter_api_calls(calls)
-        if not filtered_calls:
-            self.AddLine("    ALL API CALLS ARE EXCLUDED")
-            return
-
-        for call in filtered_calls:
-            self.AddLine(call)
+        """Function-scope trace: API calls made directly from the current function."""
+        self._render_trace(
+            self.xrefer_obj.gather_sorted_function_api_calls(self.func_ea),
+            "    NO API CALLS FOUND FOR CURRENT FUNCTION",
+        )
 
     def handle_trace_scope_path(self) -> None:
-        """
-        Handle path-scope trace display.
-
-        Shows API calls made from current function and all functions
-        called along paths from it, applying exclusions filtering.
-        """
-        self.ClearLines()
-        self.print_ribbon()
-        calls = self.xrefer_obj.gather_sorted_path_api_calls(self.func_ea)
-
-        if not calls:
-            self.AddLine("    NO API CALLS FOUND FOR CURRENT PATH")
-            return
-
-        filtered_calls = self.filter_api_calls(calls)
-        if not filtered_calls:
-            self.AddLine("    ALL API CALLS ARE EXCLUDED")
-            return
-
-        for call in filtered_calls:
-            self.AddLine(call)
+        """Path-scope trace: direct + indirect API calls reachable from the current function."""
+        self._render_trace(
+            self.xrefer_obj.gather_sorted_path_api_calls(self.func_ea),
+            "    NO API CALLS FOUND FOR CURRENT PATH",
+        )
 
     def handle_trace_scope_full(self) -> None:
-        """
-        Handle full-scope trace display.
-
-        Shows all API calls in the trace file, applying exclusions
-        filtering if enabled.
-        """
-        self.ClearLines()
-        self.print_ribbon()
-        calls = self.xrefer_obj.gather_sorted_full_api_calls()
-
-        if not calls:
-            self.AddLine("    NO API CALLS FOUND IN DATABASE")
-            return
-
-        filtered_calls = self.filter_api_calls(calls)
-        if not filtered_calls:
-            self.AddLine("    ALL API CALLS ARE EXCLUDED")
-            return
-
-        for call in filtered_calls:
-            self.AddLine(call)
+        """Full-scope trace: every API call in the trace database."""
+        self._render_trace(
+            self.xrefer_obj.gather_sorted_full_api_calls(),
+            "    NO API CALLS FOUND IN DATABASE",
+        )
 
     def handle_no_context_available(self) -> None:
         """
@@ -3763,7 +3708,7 @@ class XReferView(idaapi.simplecustviewer_t):
                             # Limit the length of the call string and add "..." if truncated
                             if len(call) > 150:
                                 call = call[:150] + "..."
-                            tooltip += f"  {call}\n"
+                            tooltip += f"  {colorize_api_call(call)}\n"
                             line_count += 1
                 else:
                     tooltip += f"\x01{entity_color_tag}{entity_content}\x02{entity_color_tag}\n"

--- a/plugins/xrefer/llm/cluster_analyzer.py
+++ b/plugins/xrefer/llm/cluster_analyzer.py
@@ -174,7 +174,7 @@ class ClusterAnalyzer:
                             for api in apis:
                                 formatted.append(f"{indent}    API: {api}")
                                 # Get top 10 calls
-                                if calls := xrefer_obj.get_direct_calls(api, node, colorized=False):
+                                if calls := xrefer_obj.get_direct_calls(api, node):
                                     sorted_calls = sorted(calls, key=lambda x: x[1], reverse=True)[:10]
                                     for call_str, count in sorted_calls:
                                         formatted.append(f"{indent}      Call: {call_str} (called {count} times)")

--- a/plugins/xrefer/llm/processor.py
+++ b/plugins/xrefer/llm/processor.py
@@ -59,7 +59,8 @@ class LLMProcessor:
             "cache_seed": 0x72616e64306d,
         }
         # match <https://github.com/stanfordnlp/dspy/blob/1df5984007b7fd9bb56f3a8fba7a68b5517efb69/dspy/clients/lm.py#L92>'s logic
-        if re.search(r'openai\/(?:o[1345]|gpt-5)(?:-(?:mini|nano|codex))?', config.model_id):
+        # gpt-5(?:\.\d+)? matches plain gpt-5 plus decimal subversions (gpt-5.4, gpt-5.5, ...).
+        if re.search(r'openai\/(?:o[1345]|gpt-5(?:\.\d+)?)(?:-(?:mini|nano|codex))?', config.model_id):
             lm_kwargs.update({"temperature": 1.0, "max_tokens": 16000})
         # For Gemini models, use full 65k output token capacity and force JSON mode
         # Gemini's structured output doesn't support dynamic object properties

--- a/plugins/xrefer/loaders/trace/cape_parser.py
+++ b/plugins/xrefer/loaders/trace/cape_parser.py
@@ -124,16 +124,10 @@ class CapeTraceParser(BaseTraceParser):
         return str(value)
 
     def _format_api_call(self, api_call: Dict[str, Any]) -> str:
-        """
-        Format complete API call for display.
+        """Format an API call as plain "(args) = ret".
 
-        Creates colored string representation including arguments and return value.
-
-        Args:
-            api_call (Dict[str, Any]): API call information dictionary
-
-        Returns:
-            str: Formatted API call string with color codes
+        Color/styling is applied later by the rendering layer (see
+        xrefer.gui.helpers.format_api_call_for_ida).
         """
         args = []
         for arg in api_call.get("arguments", []):
@@ -145,7 +139,6 @@ class CapeTraceParser(BaseTraceParser):
                 args.append(arg_value)
 
         args_str = f"({', '.join(args)})"
-        # TODO(rand0m): This is formatting. Should be in gui/. Refactoring the entire code is needed. No time for this now.  There was a colorize_api_call function in the original code.
 
         ret_val = api_call.get("return", "0x0")
         if isinstance(ret_val, str) and ret_val.startswith("0x"):

--- a/plugins/xrefer/loaders/trace/vmray_parser.py
+++ b/plugins/xrefer/loaders/trace/vmray_parser.py
@@ -113,18 +113,6 @@ class VMRayTraceParser(BaseTraceParser):
 
         return param_dict
 
-    def _format_call_str(self, call_str_base: str, return_str: str) -> str:
-        """Format call string; use IDA-style colors when available, else plain text."""
-        try:
-            import ida_lines
-            from xrefer.gui.helpers import colorize_api_call
-
-            colored_call = colorize_api_call(call_str_base)
-            colored_ret = ida_lines.COLSTR(str(return_str), ida_lines.SCOLOR_DSTR)
-            return f"{colored_call} \x01{ida_lines.SCOLOR_DEMNAME}=\x02{ida_lines.SCOLOR_DEMNAME} {colored_ret}"
-        except Exception as e:
-            return f"{call_str_base} = {return_str}"
-
     def _correlate_memory_regions(self, summary_json: dict, flog_root: ET.Element) -> Dict[str, Dict]:
         """
         Correlates file paths/hashes from summary_v2.json with memory_mapped_file regions in flog.xml.
@@ -317,9 +305,8 @@ class VMRayTraceParser(BaseTraceParser):
                         args_str.append(str(value))
 
                 call_str_base = f"({', '.join(args_str)})"
-                # TODO(rand0m): This is formatting. Should be in gui/. Refactoring the entire code is needed. No time for this now.  There was a colorize_api_call function in the original code.
                 return_str = str(return_value or "0")
-                call_str = self._format_call_str(call_str_base, return_str)
+                call_str = f"{call_str_base} = {return_str}"
 
                 full_name = self.get_standard_api_name(api_name, known_imports)
                 formatted_args = self.format_arg_list(in_params)

--- a/requirements-ida.txt
+++ b/requirements-ida.txt
@@ -10,3 +10,4 @@ requests>=2.32.4
 tabulate>=0.9.0
 idapro
 msgpack>=1.1.1
+qtpy>=2.4.0


### PR DESCRIPTION
## Summary
Six commits hardening the gsoc_2025 plugin against IDA 9.3, native PySide6, and real LLM workloads. Each commit is one logical concern.

1. **Tier 3 API trace: record-based pipeline** — producers emit `List[ApiCall]` (frozen dataclass); GUI/HTML consumers format on demand. Restores per-call colorization in IDA's custom viewer that regressed vs `main`.
2. **qtpy migration + IDA 9.3 TWidget bridge** — replace direct PyQt5 imports with qtpy across `gui/*` and the analyzer's missing-files dialog. `gui/helpers.twidget_to_qt()` prefers `TWidgetToQtPythonWidget` (PySide6-native via shiboken6) over the broken `TWidgetToPySideWidget`. Plugin loads under both the IDA PyQt5 shim ("Yes" on IDA's binding dialog) and native PySide6 ("No").
3. **Cluster decomposition + small-binary fallback + graceful LLM-failure path** — stop force-adding the entry point into the candidate set (was merging otherwise-separate clusters into one through the EP root); fall back to a single degenerate cluster rooted at the EP for tiny binaries; coerce restored state on LLM-failure paths to safe defaults so the trailing `assert self.clusters is not None` can't fire on first-run failures, while preserving the rollback-to-prior-good behavior on re-runs.
4. **Qt lifecycle robustness** — `qt_object_alive()` probes the active binding's introspection module (shiboken6/shiboken2/sip) to distinguish None / destroyed-wrapper / live; identity-bound destroyed handler so a deferred fire from an old widget can't clobber a freshly-rebuilt `qt_widget`; `cleanup()` rewritten with per-access guards; named methods replace deferred QTimer lambdas; `get_parent_table` handles `GetLineNo(mouse=1)`'s `-1` sentinel explicitly (truthy in Python; would have hit `GetLine(-1)` SWIG failure).
5. **`Address`→`int` at SWIG boundary; recurse cluster graph; unify indentation** — IDA 9.3's SWIG bindings strict-typecheck `ea_t` and reject the `int` subclass `xrefer.backend.base.Address`; cast at three sites in `create_cluster_rows`. Recursive `_process` in `create_cluster_relationship_graph` so multi-level cluster hierarchies render (the previous loop silently dropped subclusters past depth 1). Drop OS-conditional indent and heading prefix that left macOS visibly shallower than other platforms.
6. **LLM model dropdown driven by `litellm.model_cost`** — dynamic curation of models meeting structured-output (`response_schema` or function-calling) + ≥1M input + ≥16k output requirements, restricted to direct-API providers (openai/gemini/xai). Anthropic excluded: litellm reports `max_input_tokens=1_000_000` for Claude 4.x but that 1M is beta-gated (anthropic-beta header + tier 4+) — listing them would over-promise and 4xx at runtime on real prompts. Combo stays editable so users can type any model id. Also fixes the gpt-5 regex in `processor.py` so `gpt-5.4`/`gpt-5.5` get the same `temperature=1.0` special-casing as `gpt-5`.

## Test plan
- [x] Plugin loads under both PyQt5 shim ("Yes" on IDA's binding dialog) and native PySide6 ("No")
- [x] Tier 3 API trace renders with addresses and API names colored, args/return colored
- [x] Clusters decompose into multiple distinct groups (no merging through the EP) on a normal-sized binary
- [x] Tiny binaries still produce a single fallback cluster instead of an empty view
- [x] First-run LLM failure (e.g. invalid API key, no network) renders empty state cleanly — no AssertionError
- [x] Re-run after a successful run preserves prior cluster shape/labels on transient LLM failure
- [x] Close the dock and reopen from menu — view rebuilds, no crash on stale references
- [x] Settings dialog dropdown shows ~40 entries grouped gemini/openai/xai, no Anthropic; field remains editable for user-typed model ids