### PR TITLE
xrefer: single-source versioning (1.1.20260604) + drop redundant self.version

### DIFF
--- a/plugins/xrefer/__init__.py
+++ b/plugins/xrefer/__init__.py
@@ -17,7 +17,13 @@
 # The previous subprocess.Popen patch existed only to suppress the Java console
 # window when asciinet spawned a JVM server; with no JVM it is no longer needed.
 
-__version__ = "2.2025-10-30"
+# ``__version__`` lives in a sibling module with zero imports so
+# setuptools' AST-based ``attr:`` reader can resolve it at build time
+# without importing the whole package. To bump the release version,
+# edit ``plugins/xrefer/_version.py`` — that is the single source of
+# truth. See pyproject.toml's ``[tool.setuptools.dynamic]`` section
+# for the wiring.
+from ._version import __version__
 
 from . import core, lang, llm, loaders
 __all__ = ["core", "lang", "llm", "loaders", "__version__"]

--- a/plugins/xrefer/_version.py
+++ b/plugins/xrefer/_version.py
@@ -1,0 +1,30 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Single source of truth for xrefer's release version.
+#
+# Format: ``MAJOR.MINOR.YYYYMMDD`` — PEP 440-compliant, three numeric
+# segments separated by dots. Bump this constant when cutting a release;
+# everything downstream (the package's ``__version__`` attribute,
+# ``pyproject.toml``'s build-time version, the IDA startup log, the
+# About dialog, the HTML report metadata) reads from here.
+#
+# This file deliberately has NO imports so setuptools' AST-based
+# ``attr:`` reader can resolve the version statically — without
+# importing the ``xrefer`` package — at build/lock time. Keep it that
+# way; adding any import would force a dynamic-import fallback that
+# breaks ``uv lock`` because of the ``plugins/xrefer.py`` IDA-loader
+# vs. ``plugins/xrefer/`` package name collision.
+
+__version__ = "1.1.20260604"

--- a/plugins/xrefer/plugin.py
+++ b/plugins/xrefer/plugin.py
@@ -16,6 +16,7 @@ from typing import Optional
 
 import idaapi
 
+from xrefer import __version__
 from xrefer.gui.action_handlers import *
 from xrefer.gui.helpers import *
 from xrefer.gui.view import XReferView
@@ -33,7 +34,8 @@ class XReferPlugin(idaapi.plugin_t):
         wanted_name (str): Display name of the plugin in IDA.
         wanted_hotkey (str): Default hotkey to activate the plugin.
         xrefer_view (Optional[XReferView]): The plugin's main view instance.
-        version (float): Plugin version number.
+        version (str): Plugin version number, sourced from ``xrefer.__version__``
+            (the single source of truth — see ``plugins/xrefer/__init__.py``).
     """
 
     flags: int = idaapi.PLUGIN_KEEP
@@ -43,7 +45,7 @@ class XReferPlugin(idaapi.plugin_t):
     def __init__(self):
         """Initialize plugin with empty view."""
         self.xrefer_view = None
-        self.version = 1.0
+        self.version = __version__
 
     def init(self) -> int:
         """

--- a/plugins/xrefer/plugin.py
+++ b/plugins/xrefer/plugin.py
@@ -34,8 +34,6 @@ class XReferPlugin(idaapi.plugin_t):
         wanted_name (str): Display name of the plugin in IDA.
         wanted_hotkey (str): Default hotkey to activate the plugin.
         xrefer_view (Optional[XReferView]): The plugin's main view instance.
-        version (str): Plugin version number, sourced from ``xrefer.__version__``
-            (the single source of truth — see ``plugins/xrefer/__init__.py``).
     """
 
     flags: int = idaapi.PLUGIN_KEEP
@@ -45,7 +43,6 @@ class XReferPlugin(idaapi.plugin_t):
     def __init__(self):
         """Initialize plugin with empty view."""
         self.xrefer_view = None
-        self.version = __version__
 
     def init(self) -> int:
         """
@@ -101,7 +98,7 @@ class XReferPlugin(idaapi.plugin_t):
         Args:
             arg (int): IDA argument value (unused).
         """
-        log(f"Binary Navigator v{self.version} is loaded. Browse to Edit -> XRefer.")
+        log(f"Binary Navigator v{__version__} is loaded. Browse to Edit -> XRefer.")
 
 
 class ContextHooks(idaapi.UI_Hooks):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,14 @@ authors = [
   {name = "binjo" },
   {name = "rand-tech" },
 ]
-version = "2.0.0.20251030"
+# Version is sourced dynamically from ``plugins/xrefer/_version.py``
+# (the single source of truth — a tiny no-imports module so
+# setuptools' AST static reader can resolve it without importing the
+# package). To bump the release, edit that file. The package-level
+# ``xrefer.__version__`` re-exports the same constant; runtime
+# consumers (About dialog, HTML report, IDA startup log) read from
+# whichever is convenient.
+dynamic = ["version"]
 description = "FLARE Team's Binary Navigator"
 requires-python = ">=3.11"
 dependencies = [
@@ -57,11 +64,26 @@ override-dependencies = [
 requires = ["setuptools>=68", "wheel"]
 build-backend = "setuptools.build_meta"
 
+[tool.setuptools]
+# ``plugins/xrefer.py`` is the IDA-plugin entry-point file (loaded by
+# IDA's plugin scanner) — NOT a top-level Python module to install.
+# Explicitly opt out of py-module auto-discovery so setuptools doesn't
+# try to package it (which collides with the ``plugins/xrefer/`` package
+# and breaks build-time metadata resolution).
+py-modules = []
+
 [tool.setuptools.package-dir]
 "" = "plugins"
 
 [tool.setuptools.packages.find]
 where = ["plugins"]
+
+[tool.setuptools.dynamic]
+# Reads ``plugins/xrefer/_version.py`` via setuptools' static AST
+# reader — that file has no imports so resolution never falls back to
+# a dynamic import (which would collide with ``plugins/xrefer.py``,
+# the IDA-loader entry-point file, and break the build).
+version = {attr = "xrefer._version.__version__"}
 
 [project.urls]
 source = "https://github.com/mandiant/xrefer"


### PR DESCRIPTION
## What

Consolidates xrefer's version into a single source of truth and resets
the release line to `1.1.20260604`.

## Why

The version was declared independently in five places that had drifted
out of sync:

| Source | Value |
|--------|-------|
| `pyproject.toml` | `2.0.0.20251030` |
| `plugins/xrefer/__init__.py` | `2.2025-10-30` (not valid PEP 440 — dashes) |
| `uv.lock` | `2.0.0.20251030` |
| `plugins/xrefer/plugin.py` | `self.version = 1.0` (a bare float) |
| git tags | `v1.0.0` … `v1.0.3` |

Visible symptom: the IDA startup banner logged **`v1.0`** while the
About dialog and HTML report showed **`v2.2025-10-30`**. The jump to
`2.x` was also unintended — the last release tag is `v1.0.3`.

## Changes

- **New `plugins/xrefer/_version.py`** is the single source of truth.
  Holds `__version__` as a PEP 440-compliant `MAJOR.MINOR.YYYYMMDD`
  string. The module has **no imports** so setuptools' AST-based
  `attr:` reader can resolve it statically without importing the
  package.
- `__init__.py` re-exports `__version__` from `._version`.
- `plugin.py` logs `__version__` directly in the startup banner; the
  redundant `self.version` attribute (and its docstring entry) is
  removed — it only ever mirrored `__version__` and had that single
  consumer.
- `pyproject.toml` switches to `dynamic = ["version"]` sourced via
  `attr = "xrefer._version.__version__"`. `py-modules = []` keeps the
  `plugins/xrefer.py` IDA-loader entry file out of build-time module
  discovery (resolving from the package `__init__` instead of the
  no-imports `_version.py` triggers a dynamic-import fallback that
  collides with that loader file and breaks `uv lock`).
- Resets the version line to **1.x**: next release is `1.1.20260604`.

## Notes for the reviewer

- All commits are authored by `m-umairx`.
- This branch's earlier vendor-migration (`484df59`) and SWIG-fix
  (`febd9a9`) commits already landed in `gsoc_2025` via #37/#38, so
  this PR contains **only the two version commits** (`80e7954`,
  `89498f6`).
- After merge, consider tagging `v1.1.20260604` to keep the git-tag
  source in step with `_version.py`.
