### PR TITLE
M umairx/gsoc 2025 fixups

### DIFF
--- a/plugins/xrefer/_version.py
+++ b/plugins/xrefer/_version.py
@@ -27,4 +27,4 @@
 # breaks ``uv lock`` because of the ``plugins/xrefer.py`` IDA-loader
 # vs. ``plugins/xrefer/`` package name collision.
 
-__version__ = "1.1.20260604"
+__version__ = "1.1.20260804"

--- a/plugins/xrefer/cli.py
+++ b/plugins/xrefer/cli.py
@@ -499,6 +499,9 @@ def cli():
         ),
     )
     parser.add_argument("--report-data-mode", choices=["html", "json", "none"], default="html", help="Report output format: html (standalone), json (data only), or none")
+    parser.add_argument("--emit-anatomy", nargs="?", const="__DEFAULT__", metavar="PATH",
+                        help="Export the agent-facing binary-anatomy JSON (single file) after analysis. "
+                             "Optional PATH; default <binary>_anatomy.json.")
     parser.add_argument("--force", action="store_true", help="Remove previous artifacts and re-analyze")
     parser.add_argument("--entry-point", type=parse_entry_point, help="Override entry point address (decimal or hex like 0x401000)")
     parser.add_argument("-L", "--logfile", help="Output log file path")
@@ -660,6 +663,13 @@ def cli():
                 print("[!] Analysis completed with warnings (see above)")
             else:
                 print("[+] Analysis completed successfully")
+
+            if args.emit_anatomy is not None and analysis_result is not None:
+                from xrefer.core.agent_map import export_anatomy
+                _anat_out = (args.emit_anatomy if args.emit_anatomy != "__DEFAULT__"
+                             else f"{file_path}_anatomy.json")
+                export_anatomy(analysis_result, str(_anat_out))
+                print(f"[+] Agent anatomy written to: {_anat_out}")
         except KeyboardInterrupt:
             print("\n[!] Analysis interrupted by user")
             sys.exit(1)

--- a/plugins/xrefer/cli.py
+++ b/plugins/xrefer/cli.py
@@ -502,6 +502,9 @@ def cli():
     parser.add_argument("--emit-anatomy", nargs="?", const="__DEFAULT__", metavar="PATH",
                         help="Export the agent-facing binary-anatomy JSON (single file) after analysis. "
                              "Optional PATH; default <binary>_anatomy.json.")
+    parser.add_argument("--emit-agent-map", nargs="?", const="__DEFAULT__", metavar="DIR",
+                        help="Export the tiered agent-map bundle (map.json + clusters/ + indices/) after "
+                             "analysis. Optional DIR; default <binary>_agent_map/.")
     parser.add_argument("--force", action="store_true", help="Remove previous artifacts and re-analyze")
     parser.add_argument("--entry-point", type=parse_entry_point, help="Override entry point address (decimal or hex like 0x401000)")
     parser.add_argument("-L", "--logfile", help="Output log file path")
@@ -670,6 +673,13 @@ def cli():
                              else f"{file_path}_anatomy.json")
                 export_anatomy(analysis_result, str(_anat_out))
                 print(f"[+] Agent anatomy written to: {_anat_out}")
+
+            if args.emit_agent_map is not None and analysis_result is not None:
+                from xrefer.core.agent_map import export_agent_map
+                _map_out = (args.emit_agent_map if args.emit_agent_map != "__DEFAULT__"
+                            else f"{file_path}_agent_map")
+                export_agent_map(analysis_result, str(_map_out))
+                print(f"[+] Agent map bundle written to: {_map_out}/")
         except KeyboardInterrupt:
             print("\n[!] Analysis interrupted by user")
             sys.exit(1)

--- a/plugins/xrefer/core/agent_map.py
+++ b/plugins/xrefer/core/agent_map.py
@@ -51,23 +51,21 @@ GUESS = "xrefer_llm_guess"
 # SINGLE-FILE ONLY cap on emitted signal clusters (the tiered bundle emits every cluster). Keeps the
 # pasteable file bounded; set (21) so a ranked-low payload — e.g. an embedded-crypto engine whose danger
 # floor never fired (typically ~#20) — still makes the file. Danger-floor clusters cut by the cap are
-# flagged in coverage.omitted.notable_rvas, and dependency_bom surfaces crypto crates regardless of the
-# cap, so the crypto-miss the removed 15-cap caused cannot recur here.
+# flagged in coverage.omitted.notable_rvas (anti-hiding); a signal cluster below the cap with no danger
+# floor is not flagged, so keep this generous.
 MAX_SINGLE_FILE_CLUSTERS = 21
 MAX_FUNCS_PER_CLUSTER = 6   # curation: keep the most artifact-dense functions per cluster (+ root)
 MAX_CALL_SITES = 3          # curation: call-site RVAs kept per artifact
 MAX_ARTIFACTS_PER_TYPE = 5  # curation: apis/strings/capa/api_trace kept per function
 MAX_STR_LEN = 80            # curation: truncate long string/artifact names
 
-# Dependency-BOM tiering (options i + ii). A crate root referenced across a large fraction
-# of clusters is pervasive infrastructure (language runtime, or the sample's own ubiquitous
-# core) and is demoted to a compact appendix + filtered out of per-function libs; a
-# cluster-local crate is a SIGNAL dependency (crypto/compression/parsers/…) surfaced first.
-# The split is by reference SPREAD, never by crate NAME, so a novel/renamed crypto crate
-# surfaces exactly like a known one. The floor keeps tiny binaries from over-demoting.
+# Per-cluster libs filter. A crate root referenced across a large fraction of clusters is pervasive
+# infrastructure (language runtime, or the sample's own ubiquitous core) and is dropped from the
+# per-function libs so it does not drown the signal; a cluster-local crate (crypto/compression/parsers/…)
+# is kept. The split is by reference SPREAD, never by crate NAME, so a novel/renamed crypto crate is
+# kept exactly like a known one. The floor keeps tiny binaries from over-demoting.
 RUNTIME_CRATE_MIN_CLUSTERS = 8
 RUNTIME_CRATE_CLUSTER_FRACTION = 0.30
-MAX_BOM_CLUSTERS_PER_CRATE = 6   # cap the crate->cluster pointer list (single-file leanness)
 
 # Deterministic danger-floor API-name sets, matched on the lowercased API basename.
 # STATIC: independent of any LLM flag. A cluster reaching one of these is never
@@ -304,36 +302,17 @@ class _Builder:
         return name.split("::", 1)[0] if name else None
 
     def _crate_index(self) -> Dict[str, Dict[str, Any]]:
-        """Static crate dependency index keyed by crate root, aggregated across the whole
-        binary: reference volume, distinct clusters, entity idxs. Cached.
+        """Static crate index keyed by crate root, over the crates referenced inside clusters:
+        each root's distinct-cluster spread and a pervasive/signal flag. Cached.
 
         A crate referenced across a large fraction of clusters is pervasive infrastructure
         (language runtime, or the sample's own ubiquitous core); a cluster-local crate is a
-        SIGNAL dependency (crypto/compression/parsers). The split is by reference SPREAD,
-        never by crate name, so an embedded crypto crate (chacha20/aes/rsa) surfaces the same
-        way a named one would. Drives the dependency BOM and the per-function libs filter."""
+        SIGNAL dependency (crypto/compression/parsers). The split is by reference SPREAD, never
+        by crate name, so an embedded crypto crate (chacha20/aes/rsa) is kept the same way a
+        named one would be. Drives the per-function libs filter (`_runtime_roots`)."""
         if self._crate_cache is not None:
             return self._crate_cache
         index: Dict[str, Dict[str, Any]] = {}
-        # Reference volume + entity idxs across ALL functions (completeness: includes crates
-        # referenced only by unclustered code).
-        for ea in self.gx:
-            for idx in self._entry(ea, self.DIRECT).get("libs", ()):
-                root = self._crate_root(idx)
-                if root is None:
-                    continue
-                s = index.get(root)
-                if s is None:
-                    s = {"crate": root, "xrefs": 0, "entity_idxs": set(), "clusters": set()}
-                    index[root] = s
-                s["entity_idxs"].add(idx)
-        for s in index.values():
-            for idx in s["entity_idxs"]:
-                try:
-                    s["xrefs"] += len(self.x.entity_xrefs.get(idx, ()) or ())
-                except Exception:
-                    pass
-        # Cluster spread = the pervasiveness signal (and the crate->cluster bridge).
         total_clusters = 0
         for cl in self._iter_clusters():
             total_clusters += 1
@@ -345,8 +324,7 @@ class _Builder:
                     if root is not None:
                         seen.add(root)
             for root in seen:
-                if root in index:
-                    index[root]["clusters"].add(rrva)
+                index.setdefault(root, {"crate": root, "clusters": set()})["clusters"].add(rrva)
         self._crate_cutoff = max(float(RUNTIME_CRATE_MIN_CLUSTERS),
                                  RUNTIME_CRATE_CLUSTER_FRACTION * total_clusters)
         for s in index.values():
@@ -361,44 +339,6 @@ class _Builder:
         if self._runtime_cache is None:
             self._runtime_cache = {r for r, s in self._crate_index().items() if s["pervasive"]}
         return self._runtime_cache
-
-    def _dependency_bom(self, lean: bool) -> Dict[str, Any]:
-        """Binary-level crate/library parts list (option ii). `signal` = cluster-local
-        dependencies (the authoritative view — a linked crypto crate is EVIDENCE here, not
-        noise), ranked most-specific first; `pervasive` = crates spread across most clusters
-        (runtime/infra), kept for completeness. Present in both formats; `lean` drops
-        entity_idxs for the single file (its lean entity catalog would not carry them)."""
-        index = self._crate_index()
-        signal: List[Dict[str, Any]] = []
-        pervasive: List[Dict[str, Any]] = []
-        for s in index.values():
-            if s["pervasive"]:
-                pervasive.append({"crate": s["crate"], "xrefs": s["xrefs"], "n_clusters": s["n_clusters"]})
-                continue
-            row: Dict[str, Any] = {"crate": s["crate"], "xrefs": s["xrefs"], "n_clusters": s["n_clusters"]}
-            clist = sorted(s["clusters"])
-            row["clusters_rva"] = clist[:MAX_BOM_CLUSTERS_PER_CRATE]
-            if len(clist) > MAX_BOM_CLUSTERS_PER_CRATE:
-                row["clusters_omitted"] = len(clist) - MAX_BOM_CLUSTERS_PER_CRATE
-            if not lean:
-                row["entity_idxs"] = sorted(s["entity_idxs"])[:12]
-            signal.append(row)
-        signal.sort(key=lambda r: (r["n_clusters"], -r["xrefs"], r["crate"]))
-        pervasive.sort(key=lambda r: (-r["xrefs"], r["crate"]))
-        return {
-            "_comment": ("Static crate/library dependency inventory (provenance: static, from linked "
-                         "symbols). `signal` = cluster-local dependencies (crypto, compression, parsers, "
-                         "the sample's own modules) ranked most-specific first — the authoritative parts "
-                         "list; a statically-linked crypto crate here is EVIDENCE, not noise. `pervasive` "
-                         "= crates referenced across most clusters (language/runtime, or the sample's own "
-                         "ubiquitous core), listed for completeness. Split by reference spread, never by "
-                         "crate name. clusters_rva points to the cluster(s) that use the crate. REPORT "
-                         "EVERY cipher/crypto crate here; confirm which is primary vs secondary by reading "
-                         "the bodies at those clusters."),
-            "signal": signal,
-            "pervasive": pervasive,
-            "pervasive_threshold_clusters": round(self._crate_cutoff, 2),
-        }
 
     def _cluster_static(self, cluster: Any) -> Dict[str, Any]:
         root = cluster.root_node
@@ -491,8 +431,7 @@ class _Builder:
 
         # Single-file cap: top-N signal clusters by static score are shown; the rest are omitted
         # (danger-floor ones flagged in coverage.omitted.notable_rvas). SINGLE FILE ONLY — the tiered
-        # bundle emits every cluster. The cap is generous (30) so a ranked-low payload survives, and
-        # dependency_bom surfaces crypto crates independently of it.
+        # bundle emits every cluster. The cap is kept generous so a ranked-low payload survives.
         shown = 0
         for score, cl, static_lib, llm_lib, danger, why in scored:
             root_rva = self.rva(cl.root_node)
@@ -509,7 +448,7 @@ class _Builder:
             if promoted:
                 promoted_out.append(root_rva)
             # cap: signal clusters beyond MAX go to the omission ledger (danger-floor ones flagged
-            # so the anti-hiding net survives; dependency_bom still carries any crypto crates).
+            # so the anti-hiding net survives).
             if shown >= MAX_SINGLE_FILE_CLUSTERS:
                 if danger is not None:
                     omitted_notable.append({"rva": root_rva,
@@ -554,7 +493,6 @@ class _Builder:
                              "read_first_rva": [queue[0]["ref_rva"]] if queue else []},
             "verdict": {"claim": {"v": self.ca.get("binary_category") if has_llm else None, "src": GUESS,
                                   "verdict": None}},
-            "dependency_bom": self._dependency_bom(lean=True),
             "investigation_queue": queue,
             "clusters": clusters_out,
             "noise": {"static_lib_count": len(static_lib_roots),
@@ -642,9 +580,6 @@ class _Builder:
                 "on_mismatch": "REFUSE: wrong sample or wrong base. Do not r2_decompile these RVAs or apply an annotation."}
 
     def _readme(self, shown: int, total: int, static_lib: int, llm_lib: int) -> Dict[str, Any]:
-        idx = self._crate_index()
-        n_sig = sum(1 for s in idx.values() if not s["pervasive"])
-        n_perv = sum(1 for s in idx.values() if s["pervasive"])
         return {
             "format": "xrefer-binary-anatomy",
             "prerequisite": ("FIRST confirm the malware_analysis and format_binary skills are active in "
@@ -657,13 +592,12 @@ class _Builder:
             "provenance": ("BARE values = STATIC ground truth (RVAs, imports, xrefs, paths, capa, "
                            "category=='func_lib'/is_simple_api_thunk). Objects with src=='xrefer_llm_guess' = "
                            "HYPOTHESIS. NOTE: cluster is_library/llm_lib and per-function origin are LLM-derived; "
-                           "the static library signal is category=='func_lib'. dependency_bom + per-function "
-                           "artifacts.libs are STATIC crate refs, filtered to cluster-local (signal) crates. "
+                           "the static library signal is category=='func_lib'. Per-function artifacts.libs are "
+                           "STATIC crate refs, filtered to cluster-local (signal) crates. "
                            "type_id: 1=lib 2=api 3=string 4=capa 5=api_trace."),
             "capability_gate_applies": True,
             "counts": {"clusters_shown": shown, "clusters_total": total,
-                       "clusters_static_lib": static_lib, "clusters_llm_lib": llm_lib,
-                       "dependency_crates_signal": n_sig, "dependency_crates_pervasive": n_perv},
+                       "clusters_static_lib": static_lib, "clusters_llm_lib": llm_lib},
         }
 
     def _report_scaffold(self) -> Dict[str, Any]:
@@ -1257,7 +1191,6 @@ class _Builder:
             },
             "provenance_legend": self._provenance_legend(),
             "stats": stats,
-            "dependency_bom": self._dependency_bom(lean=False),
             "binary": {
                 "provenance": "llm",
                 "category": self.ca.get("binary_category") if has_llm else None,

--- a/plugins/xrefer/core/agent_map.py
+++ b/plugins/xrefer/core/agent_map.py
@@ -56,6 +56,16 @@ MAX_CALL_SITES = 3          # curation: call-site RVAs kept per artifact
 MAX_ARTIFACTS_PER_TYPE = 5  # curation: apis/strings/capa/api_trace kept per function
 MAX_STR_LEN = 80            # curation: truncate long string/artifact names
 
+# Dependency-BOM tiering (options i + ii). A crate root referenced across a large fraction
+# of clusters is pervasive infrastructure (language runtime, or the sample's own ubiquitous
+# core) and is demoted to a compact appendix + filtered out of per-function libs; a
+# cluster-local crate is a SIGNAL dependency (crypto/compression/parsers/…) surfaced first.
+# The split is by reference SPREAD, never by crate NAME, so a novel/renamed crypto crate
+# surfaces exactly like a known one. The floor keeps tiny binaries from over-demoting.
+RUNTIME_CRATE_MIN_CLUSTERS = 8
+RUNTIME_CRATE_CLUSTER_FRACTION = 0.30
+MAX_BOM_CLUSTERS_PER_CRATE = 6   # cap the crate->cluster pointer list (single-file leanness)
+
 # Deterministic danger-floor API-name sets, matched on the lowercased API basename.
 # STATIC: independent of any LLM flag. A cluster reaching one of these is never
 # silently demoted, even if the LLM called it "library".
@@ -128,6 +138,11 @@ class _Builder:
         # Function-object cache for has_default_name / name (backend-abstracted,
         # still IDA-free — Address is a plain int subclass on the base backend).
         self._fn_cache: Dict[int, Any] = {}
+        # Crate/library dependency index (lazy; built once, drives the dependency BOM
+        # and the per-function libs signal/pervasive filter).
+        self._crate_cache: Optional[Dict[str, Dict[str, Any]]] = None
+        self._crate_cutoff: float = 0.0
+        self._runtime_cache: Optional[Set[str]] = None
         # Persisted-cluster fallbacks for per-function category/origin. classify_functions()
         # (and the live backend function queries it needs) only work when the backend is
         # fully live (in-IDA). In a headless load-from-cache export the backend can be dark,
@@ -197,7 +212,7 @@ class _Builder:
         d = self._entry(ea, self.DIRECT)
         if not d:
             return out
-        # Curation: drop library refs (low signal); keep apis/strings/capa/api_trace, capped per type.
+        # Keep apis/strings/capa/api_trace, capped per type.
         for setkey, eakey, outkey in (
             ("imports", "imports_ea", "apis"), ("strings", "strings_ea", "strings"),
             ("capa", "capa_ea", "capa"), ("api_trace", "api_trace_ea", "api_trace"),
@@ -215,6 +230,31 @@ class _Builder:
                 if len(sites) > MAX_CALL_SITES:
                     entry["call_sites_omitted"] = len(sites) - MAX_CALL_SITES
                 out[outkey].append(entry)
+        # libs (option i): re-include crate refs as per-function evidence, but only SIGNAL
+        # crates (cluster-local: crypto/compression/parsers). Pervasive runtime crates
+        # (std/alloc/core, referenced across most clusters) stay dropped so they do not drown
+        # the signal — the crate BOM's whole point is that a linked crypto crate is evidence,
+        # not noise. Rarest (most cluster-specific) crate first, then capped.
+        runtime = self._runtime_roots()
+        index = self._crate_index()
+        lib_rows: List[Tuple[int, str, Dict[str, Any]]] = []
+        for idx in d.get("libs", ()):
+            root = self._crate_root(idx)
+            if root is None or root in runtime:
+                continue
+            try:
+                name = str(self.entities[idx][1])
+            except Exception:
+                name = str(idx)
+            if len(name) > MAX_STR_LEN:
+                name = name[:MAX_STR_LEN] + "…"
+            sites = sorted(self.rva(a) for a in d.get("libs_ea", {}).get(idx, ()))
+            entry = {"entity_idx": idx, "name": name, "call_site_rvas": sites[:MAX_CALL_SITES]}
+            if len(sites) > MAX_CALL_SITES:
+                entry["call_sites_omitted"] = len(sites) - MAX_CALL_SITES
+            lib_rows.append((index.get(root, {}).get("n_clusters", 0), name, entry))
+        lib_rows.sort(key=lambda t: (t[0], t[1]))
+        out["libs"] = [t[2] for t in lib_rows[:MAX_ARTIFACTS_PER_TYPE]]
         return {k: v for k, v in out.items() if v}
 
     # ---------------- cluster-level static ----------------
@@ -248,6 +288,113 @@ class _Builder:
         return {
             "reachable": True, "min_depth": len(shortest) - 1,
             "via_path_rvas": [self.rva(e) for e in shortest], "n_paths": len(plist),
+        }
+
+    # ---------------- dependency BOM (crate/library inventory) ----------------
+    def _crate_root(self, idx: int) -> Optional[str]:
+        """Crate/library root = the segment before the first '::' of a lib entity name
+        (e.g. 'chacha20::backend::sse2' -> 'chacha20'). Generic: no name list."""
+        try:
+            name = str(self.entities[idx][1])
+        except Exception:
+            return None
+        return name.split("::", 1)[0] if name else None
+
+    def _crate_index(self) -> Dict[str, Dict[str, Any]]:
+        """Static crate dependency index keyed by crate root, aggregated across the whole
+        binary: reference volume, distinct clusters, entity idxs. Cached.
+
+        A crate referenced across a large fraction of clusters is pervasive infrastructure
+        (language runtime, or the sample's own ubiquitous core); a cluster-local crate is a
+        SIGNAL dependency (crypto/compression/parsers). The split is by reference SPREAD,
+        never by crate name, so an embedded crypto crate (chacha20/aes/rsa) surfaces the same
+        way a named one would. Drives the dependency BOM and the per-function libs filter."""
+        if self._crate_cache is not None:
+            return self._crate_cache
+        index: Dict[str, Dict[str, Any]] = {}
+        # Reference volume + entity idxs across ALL functions (completeness: includes crates
+        # referenced only by unclustered code).
+        for ea in self.gx:
+            for idx in self._entry(ea, self.DIRECT).get("libs", ()):
+                root = self._crate_root(idx)
+                if root is None:
+                    continue
+                s = index.get(root)
+                if s is None:
+                    s = {"crate": root, "xrefs": 0, "entity_idxs": set(), "clusters": set()}
+                    index[root] = s
+                s["entity_idxs"].add(idx)
+        for s in index.values():
+            for idx in s["entity_idxs"]:
+                try:
+                    s["xrefs"] += len(self.x.entity_xrefs.get(idx, ()) or ())
+                except Exception:
+                    pass
+        # Cluster spread = the pervasiveness signal (and the crate->cluster bridge).
+        total_clusters = 0
+        for cl in self._iter_clusters():
+            total_clusters += 1
+            rrva = self.rva(cl.root_node)
+            seen: Set[str] = set()
+            for node in cl.nodes:
+                for idx in self._entry(node, self.DIRECT).get("libs", ()):
+                    root = self._crate_root(idx)
+                    if root is not None:
+                        seen.add(root)
+            for root in seen:
+                if root in index:
+                    index[root]["clusters"].add(rrva)
+        self._crate_cutoff = max(float(RUNTIME_CRATE_MIN_CLUSTERS),
+                                 RUNTIME_CRATE_CLUSTER_FRACTION * total_clusters)
+        for s in index.values():
+            s["n_clusters"] = len(s["clusters"])
+            s["pervasive"] = s["n_clusters"] >= self._crate_cutoff
+        self._crate_cache = index
+        return index
+
+    def _runtime_roots(self) -> Set[str]:
+        """Crate roots classified as pervasive infrastructure (filtered out of per-function
+        libs so the cluster-local signal survives). Cached — called per cluster node."""
+        if self._runtime_cache is None:
+            self._runtime_cache = {r for r, s in self._crate_index().items() if s["pervasive"]}
+        return self._runtime_cache
+
+    def _dependency_bom(self, lean: bool) -> Dict[str, Any]:
+        """Binary-level crate/library parts list (option ii). `signal` = cluster-local
+        dependencies (the authoritative view — a linked crypto crate is EVIDENCE here, not
+        noise), ranked most-specific first; `pervasive` = crates spread across most clusters
+        (runtime/infra), kept for completeness. Present in both formats; `lean` drops
+        entity_idxs for the single file (its lean entity catalog would not carry them)."""
+        index = self._crate_index()
+        signal: List[Dict[str, Any]] = []
+        pervasive: List[Dict[str, Any]] = []
+        for s in index.values():
+            if s["pervasive"]:
+                pervasive.append({"crate": s["crate"], "xrefs": s["xrefs"], "n_clusters": s["n_clusters"]})
+                continue
+            row: Dict[str, Any] = {"crate": s["crate"], "xrefs": s["xrefs"], "n_clusters": s["n_clusters"]}
+            clist = sorted(s["clusters"])
+            row["clusters_rva"] = clist[:MAX_BOM_CLUSTERS_PER_CRATE]
+            if len(clist) > MAX_BOM_CLUSTERS_PER_CRATE:
+                row["clusters_omitted"] = len(clist) - MAX_BOM_CLUSTERS_PER_CRATE
+            if not lean:
+                row["entity_idxs"] = sorted(s["entity_idxs"])[:12]
+            signal.append(row)
+        signal.sort(key=lambda r: (r["n_clusters"], -r["xrefs"], r["crate"]))
+        pervasive.sort(key=lambda r: (-r["xrefs"], r["crate"]))
+        return {
+            "_comment": ("Static crate/library dependency inventory (provenance: static, from linked "
+                         "symbols). `signal` = cluster-local dependencies (crypto, compression, parsers, "
+                         "the sample's own modules) ranked most-specific first — the authoritative parts "
+                         "list; a statically-linked crypto crate here is EVIDENCE, not noise. `pervasive` "
+                         "= crates referenced across most clusters (language/runtime, or the sample's own "
+                         "ubiquitous core), listed for completeness. Split by reference spread, never by "
+                         "crate name. clusters_rva points to the cluster(s) that use the crate. REPORT "
+                         "EVERY cipher/crypto crate here; confirm which is primary vs secondary by reading "
+                         "the bodies at those clusters."),
+            "signal": signal,
+            "pervasive": pervasive,
+            "pervasive_threshold_clusters": round(self._crate_cutoff, 2),
         }
 
     def _cluster_static(self, cluster: Any) -> Dict[str, Any]:
@@ -395,6 +542,7 @@ class _Builder:
                              "read_first_rva": [queue[0]["ref_rva"]] if queue else []},
             "verdict": {"claim": {"v": self.ca.get("binary_category") if has_llm else None, "src": GUESS,
                                   "verdict": None}},
+            "dependency_bom": self._dependency_bom(lean=True),
             "investigation_queue": queue,
             "clusters": clusters_out,
             "noise": {"static_lib_count": len(static_lib_roots),
@@ -482,6 +630,9 @@ class _Builder:
                 "on_mismatch": "REFUSE: wrong sample or wrong base. Do not r2_decompile these RVAs or apply an annotation."}
 
     def _readme(self, shown: int, total: int, static_lib: int, llm_lib: int) -> Dict[str, Any]:
+        idx = self._crate_index()
+        n_sig = sum(1 for s in idx.values() if not s["pervasive"])
+        n_perv = sum(1 for s in idx.values() if s["pervasive"])
         return {
             "format": "xrefer-binary-anatomy",
             "what": ("A single-file investigation PLAN produced by xrefer. NOT a finished analysis and "
@@ -490,10 +641,13 @@ class _Builder:
             "provenance": ("BARE values = STATIC ground truth (RVAs, imports, xrefs, paths, capa, "
                            "category=='func_lib'/is_simple_api_thunk). Objects with src=='xrefer_llm_guess' = "
                            "HYPOTHESIS. NOTE: cluster is_library/llm_lib and per-function origin are LLM-derived; "
-                           "the static library signal is category=='func_lib'. type_id: 1=lib 2=api 3=string 4=capa 5=api_trace."),
+                           "the static library signal is category=='func_lib'. dependency_bom + per-function "
+                           "artifacts.libs are STATIC crate refs, filtered to cluster-local (signal) crates. "
+                           "type_id: 1=lib 2=api 3=string 4=capa 5=api_trace."),
             "capability_gate_applies": True,
             "counts": {"clusters_shown": shown, "clusters_total": total,
-                       "clusters_static_lib": static_lib, "clusters_llm_lib": llm_lib},
+                       "clusters_static_lib": static_lib, "clusters_llm_lib": llm_lib,
+                       "dependency_crates_signal": n_sig, "dependency_crates_pervasive": n_perv},
         }
 
     def _report_scaffold(self) -> Dict[str, Any]:
@@ -1068,6 +1222,7 @@ class _Builder:
             },
             "provenance_legend": self._provenance_legend(),
             "stats": stats,
+            "dependency_bom": self._dependency_bom(lean=False),
             "binary": {
                 "provenance": "llm",
                 "category": self.ca.get("binary_category") if has_llm else None,

--- a/plugins/xrefer/core/agent_map.py
+++ b/plugins/xrefer/core/agent_map.py
@@ -635,6 +635,10 @@ class _Builder:
         n_perv = sum(1 for s in idx.values() if s["pervasive"])
         return {
             "format": "xrefer-binary-anatomy",
+            "prerequisite": ("FIRST confirm the malware_analysis and format_binary skills are active in "
+                             "this session, and activate them if not. This file augments that workflow — "
+                             "malware_analysis owns the report format and RE doctrine, format_binary drives "
+                             "radare2 — it does not replace them."),
             "what": ("A single-file investigation PLAN produced by xrefer. NOT a finished analysis and "
                      "contains NO decompiled code. Ranks where to point radare2 first; xrefer's "
                      "interpretations are null-verdict hypotheses you must confirm by reading the body."),
@@ -662,6 +666,9 @@ class _Builder:
                 "capabilities — the core analysis, organized BY BEHAVIOR (execution, persistence, "
                 "privilege-escalation, defense-evasion, credential-access, discovery, collection, "
                 "cryptography, command-and-control, exfiltration, impact), NOT cluster by cluster",
+                "details — a comprehensive technical walkthrough of the ENTIRE malware: its execution "
+                "flow from entry through every major component, covering the full binary (not only the "
+                "headline behaviors), each with the function RVAs and decompiled evidence behind it",
                 "host_based_indicators — files, registry keys, mutexes, services, processes, paths",
                 "network_based_indicators — C2 endpoints, URLs, protocols, ports",
                 "mitre_attack — technique IDs mapped to the behaviors you confirmed",

--- a/plugins/xrefer/core/agent_map.py
+++ b/plugins/xrefer/core/agent_map.py
@@ -42,7 +42,11 @@ from xrefer.core.helpers import find_cluster_analysis, log
 SCHEMA_VERSION = "2.0.0"
 SENTINEL = "XREFER_ANATOMY_EOF"
 GUESS = "xrefer_llm_guess"
-MAX_SIGNAL_CLUSTERS = 40  # single-file cap; beyond this -> omission ledger + fallback advice
+MAX_SIGNAL_CLUSTERS = 15    # single-file must stay pasteable; beyond this -> omission ledger / tiered bundle
+MAX_FUNCS_PER_CLUSTER = 6   # curation: keep the most artifact-dense functions per cluster (+ root)
+MAX_CALL_SITES = 3          # curation: call-site RVAs kept per artifact
+MAX_ARTIFACTS_PER_TYPE = 5  # curation: apis/strings/capa/api_trace kept per function
+MAX_STR_LEN = 80            # curation: truncate long string/artifact names
 
 # Deterministic danger-floor API-name sets, matched on the lowercased API basename.
 # STATIC: independent of any LLM flag. A cluster reaching one of these is never
@@ -95,6 +99,8 @@ class _Builder:
         except Exception as e:  # pragma: no cover - defensive
             log(f"[agent_map] classify_functions failed ({e}); origin left best-effort")
             self.placements = {}
+        # entity indices actually cited by shown functions (drives a lean entities catalog)
+        self._referenced: Set[int] = set()
         # reachable-node set for orphan detection
         self._reach_nodes: Set[int] = set()
         if self.ep is not None:
@@ -126,18 +132,24 @@ class _Builder:
         d = self._entry(ea, self.DIRECT)
         if not d:
             return out
+        # Curation: drop library refs (low signal); keep apis/strings/capa/api_trace, capped per type.
         for setkey, eakey, outkey in (
             ("imports", "imports_ea", "apis"), ("strings", "strings_ea", "strings"),
-            ("libs", "libs_ea", "libs"), ("capa", "capa_ea", "capa"),
-            ("api_trace", "api_trace_ea", "api_trace"),
+            ("capa", "capa_ea", "capa"), ("api_trace", "api_trace_ea", "api_trace"),
         ):
-            for idx in sorted(d.get(setkey, ())):
+            idxs = sorted(d.get(setkey, ()))
+            for idx in idxs[:MAX_ARTIFACTS_PER_TYPE]:
                 try:
-                    name = self.entities[idx][1]
+                    name = str(self.entities[idx][1])
                 except Exception:
                     name = str(idx)
+                if len(name) > MAX_STR_LEN:
+                    name = name[:MAX_STR_LEN] + "…"
                 sites = sorted(self.rva(a) for a in d.get(eakey, {}).get(idx, ()))
-                out[outkey].append({"entity_idx": idx, "name": name, "call_site_rvas": sites})
+                entry = {"entity_idx": idx, "name": name, "call_site_rvas": sites[:MAX_CALL_SITES]}
+                if len(sites) > MAX_CALL_SITES:
+                    entry["call_sites_omitted"] = len(sites) - MAX_CALL_SITES
+                out[outkey].append(entry)
         return {k: v for k, v in out.items() if v}
 
     # ---------------- cluster-level static ----------------
@@ -174,9 +186,23 @@ class _Builder:
         }
 
     def _cluster_static(self, cluster: Any) -> Dict[str, Any]:
-        funcs = []
+        root = cluster.root_node
+        raw = []
         for ea in sorted(cluster.nodes):
             arts = self._direct_artifacts(ea)
+            n_direct = sum(len(v) for v in arts.values())
+            raw.append((ea, arts, n_direct))
+        # Curation (single-file must stay pasteable): keep the root + artifact-bearing
+        # functions, densest first, capped. Pure call-graph filler is dropped (the agent
+        # decompiles the root and follows edges itself).
+        keep = [t for t in raw if t[2] > 0 or t[0] == root]
+        keep.sort(key=lambda t: (t[0] != root, -t[2], -self._indirect_count(t[0])))
+        shown = keep[:MAX_FUNCS_PER_CLUSTER]
+        funcs = []
+        for ea, arts, _n in shown:
+            for lst in arts.values():
+                for a in lst:
+                    self._referenced.add(a["entity_idx"])
             funcs.append({
                 "rva": self.rva(ea),
                 "category": self._category(ea),
@@ -184,10 +210,14 @@ class _Builder:
                 "indirect_artifact_count": self._indirect_count(ea),
                 "artifacts": arts,
             })
-        edges = [[self.rva(s), self.rva(t)] for (s, t) in getattr(cluster, "edges", [])]
+        # Edges dropped for single-file (the agent recovers the call graph with r2_callees);
+        # the cluster grouping + subcluster refs are the non-reproducible part we keep.
         subrefs = [{"at_node_rva": self.rva(n), "child_cluster_id": cid}
                    for n, cid in getattr(cluster, "cluster_refs", {}).items()]
-        return {"functions": funcs, "edges": edges, "subcluster_refs": subrefs}
+        return {"functions": funcs, "function_count": len(cluster.nodes),
+                "artifact_bearing_shown": len(funcs),
+                "functions_omitted": max(0, len(keep) - len(shown)),
+                "subcluster_refs": subrefs}
 
     def _safe_thunk(self, ea: int) -> bool:
         try:
@@ -349,9 +379,11 @@ class _Builder:
         return score, why
 
     def _entities_catalog(self) -> List[Dict[str, Any]]:
+        # Lean: only entities actually cited by a shown function (not the whole ~3k catalog).
         out = []
-        for idx, ent in enumerate(self.entities):
+        for idx in sorted(self._referenced):
             try:
+                ent = self.entities[idx]
                 name, type_id = ent[1], ent[2]
             except Exception:
                 continue
@@ -419,15 +451,17 @@ def build_anatomy(xrefer: Any) -> Dict[str, Any]:
 def export_anatomy(xrefer: Any, out_path: str) -> str:
     """Write the single-file anatomy JSON to ``out_path``; returns the path."""
     data = build_anatomy(xrefer)
+    # Compact JSON so the single file stays chat-pasteable.
+    _dump = lambda o: json.dumps(o, ensure_ascii=False, separators=(",", ":"))
     # fixed-point declared_bytes so the integrity trailer is exact
     data["_end"]["declared_bytes"] = 0
-    raw = json.dumps(data, indent=2)
+    raw = _dump(data)
     cur = len(raw.encode("utf-8"))
     n = cur
     for _ in range(6):
         n = cur - 1 + len(str(n))
     data["_end"]["declared_bytes"] = n
-    raw = json.dumps(data, indent=2)
+    raw = _dump(data)
     with open(out_path, "w", encoding="utf-8") as fh:
         fh.write(raw)
     log(f"[agent_map] wrote {out_path} ({len(raw.encode('utf-8'))} bytes, "

--- a/plugins/xrefer/core/agent_map.py
+++ b/plugins/xrefer/core/agent_map.py
@@ -1229,7 +1229,7 @@ def _read_agent_skill(filename: str) -> Optional[str]:
 def export_anatomy(xrefer: Any, out_path: str) -> str:
     """Write the single-file anatomy JSON to ``out_path``; returns the path.
 
-    Also drops the ``binary_anatomy`` consumer skill next to the JSON (a
+    Also drops the ``xrefer_binary_anatomy`` consumer skill next to the JSON (a
     static, one-time-install document — the JSON itself stays a single
     pasteable file)."""
     data = build_anatomy(xrefer)
@@ -1248,9 +1248,9 @@ def export_anatomy(xrefer: Any, out_path: str) -> str:
         fh.write(raw)
     log(f"[agent_map] wrote {out_path} ({len(raw.encode('utf-8'))} bytes, "
         f"{len(data['clusters'])} signal clusters, has_llm={data['meta']['has_llm_layer']})")
-    skill = _read_agent_skill("binary_anatomy.md")
+    skill = _read_agent_skill("xrefer_binary_anatomy.md")
     if skill is not None:
-        skill_path = os.path.join(os.path.dirname(os.path.abspath(out_path)), "binary_anatomy.SKILL.md")
+        skill_path = os.path.join(os.path.dirname(os.path.abspath(out_path)), "xrefer_binary_anatomy.SKILL.md")
         with open(skill_path, "w", encoding="utf-8") as fh:
             fh.write(skill)
         log(f"[agent_map] wrote consumer skill to {skill_path}")

--- a/plugins/xrefer/core/agent_map.py
+++ b/plugins/xrefer/core/agent_map.py
@@ -48,9 +48,12 @@ SCHEMA_VERSION = "2.0.0"
 _RUN_REF_RE = re.compile(r"cluster\.id\.(\d+)")
 SENTINEL = "XREFER_ANATOMY_EOF"
 GUESS = "xrefer_llm_guess"
-# NOTE: no cluster-count cap — every SIGNAL cluster is emitted so a ranked-low payload
-# (e.g. an embedded-crypto engine whose danger floor never fired) is never dropped. The
-# file grows with the count of real signal clusters; use the tiered bundle for huge binaries.
+# SINGLE-FILE ONLY cap on emitted signal clusters (the tiered bundle emits every cluster). Keeps the
+# pasteable file bounded; set generously (30) so a ranked-low payload — e.g. an embedded-crypto engine
+# whose danger floor never fired (typically ~#20) — still makes the file. Danger-floor clusters cut by
+# the cap are flagged in coverage.omitted.notable_rvas, and dependency_bom surfaces crypto crates
+# regardless of the cap, so the crypto-miss the removed 15-cap caused cannot recur here.
+MAX_SINGLE_FILE_CLUSTERS = 30
 MAX_FUNCS_PER_CLUSTER = 6   # curation: keep the most artifact-dense functions per cluster (+ root)
 MAX_CALL_SITES = 3          # curation: call-site RVAs kept per artifact
 MAX_ARTIFACTS_PER_TYPE = 5  # curation: apis/strings/capa/api_trace kept per function
@@ -486,11 +489,11 @@ class _Builder:
             scored.append((score, cl, static_lib, llm_lib, danger, why))
         scored.sort(key=lambda t: t[0], reverse=True)
 
-        # No cluster cap: every SIGNAL cluster is shown (only library/noise is demoted).
-        # Curation stays per-cluster (funcs/artifacts capped) so the file grows with the
-        # count of real signal clusters, not the whole 168-cluster projection — but a
-        # ranked-below-15 payload (e.g. an embedded-crypto engine whose danger floor never
-        # fired) is never silently dropped from the pasteable file.
+        # Single-file cap: top-N signal clusters by static score are shown; the rest are omitted
+        # (danger-floor ones flagged in coverage.omitted.notable_rvas). SINGLE FILE ONLY — the tiered
+        # bundle emits every cluster. The cap is generous (30) so a ranked-low payload survives, and
+        # dependency_bom surfaces crypto crates independently of it.
+        shown = 0
         for score, cl, static_lib, llm_lib, danger, why in scored:
             root_rva = self.rva(cl.root_node)
             # library handling
@@ -505,6 +508,15 @@ class _Builder:
             promoted = (static_lib or llm_lib) and danger is not None
             if promoted:
                 promoted_out.append(root_rva)
+            # cap: signal clusters beyond MAX go to the omission ledger (danger-floor ones flagged
+            # so the anti-hiding net survives; dependency_bom still carries any crypto crates).
+            if shown >= MAX_SINGLE_FILE_CLUSTERS:
+                if danger is not None:
+                    omitted_notable.append({"rva": root_rva,
+                                            "why": f"truncated (single-file top-{MAX_SINGLE_FILE_CLUSTERS}); statically reaches danger floor: {danger}",
+                                            "static": True})
+                continue
+            shown += 1
             node = {
                 "root_rva": root_rva,
                 "parent_cluster_id": cl.parent_cluster_id,

--- a/plugins/xrefer/core/agent_map.py
+++ b/plugins/xrefer/core/agent_map.py
@@ -1,0 +1,435 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Agent-facing "binary anatomy" export.
+
+Projects xrefer's in-memory analysis (the master_struct fields on ``XRefer`` plus
+``cluster_analysis``) into a portable, RVA-normalised, provenance-tiered JSON map
+for an external malware-analysis agent (radare2 / format_binary).
+
+Design contract (see the design mocks):
+  * STATIC ground truth = bare values (RVAs, imports, xrefs, paths, capa,
+    per-function category). The agent may state these as fact.
+  * LLM hypotheses = objects tagged ``{"v": ..., "src": "xrefer_llm_guess"}``.
+    The agent must confirm them by decompiling before citing.
+  * Cluster identity = root-function RVA. Addresses are RVAs (va - image_base);
+    the agent adds its own loader base.
+  * Library demotion is provenance-split: ``static_lib`` (all members func_lib)
+    is safe to collapse; ``llm_lib`` (the LLM library_or_runtime guess) is a
+    budget lever, kept visible; any danger-floor-reaching cluster is force-kept.
+
+Backend-agnostic and IDA-free: uses only the XRefer analyzer + backend
+abstraction + stdlib, so it runs headless across any backend.
+"""
+
+import hashlib
+import json
+from typing import Any, Dict, List, Optional, Set
+
+from xrefer.core.helpers import find_cluster_analysis, log
+
+SCHEMA_VERSION = "2.0.0"
+SENTINEL = "XREFER_ANATOMY_EOF"
+GUESS = "xrefer_llm_guess"
+MAX_SIGNAL_CLUSTERS = 40  # single-file cap; beyond this -> omission ledger + fallback advice
+
+# Deterministic danger-floor API-name sets, matched on the lowercased API basename.
+# STATIC: independent of any LLM flag. A cluster reaching one of these is never
+# silently demoted, even if the LLM called it "library".
+DANGER_FLOOR: Dict[str, Set[str]] = {
+    "process_injection": {
+        "virtualallocex", "writeprocessmemory", "createremotethread", "ntmapviewofsection",
+        "queueuserapc", "setthreadcontext", "rtlcreateuserthread", "ntcreatethreadex",
+        "virtualprotectex", "ntwritevirtualmemory", "ntprotectvirtualmemory",
+    },
+    "crypto": {
+        "cryptencrypt", "cryptdecrypt", "cryptderivekey", "cryptacquirecontext",
+        "bcryptencrypt", "bcryptdecrypt", "bcryptdecryptkey", "cryptgenkey", "cryptimportkey",
+    },
+    "net_exfil": {
+        "winhttpsendrequest", "httpsendrequest", "httpsendrequesta", "httpsendrequestw",
+        "internetopena", "internetopenw", "internetconnecta", "internetconnectw",
+        "winhttpconnect", "winhttpopen", "wsasend", "urldownloadtofilew", "urldownloadtofilea",
+    },
+    "cred_access": {
+        "lsaretrieveprivatedata", "credenumeratea", "credenumeratew", "samconnect",
+        "openprocesstoken", "lookupaccountsida", "lsaenumerateaccountrights",
+    },
+}
+
+
+def _llm(value: Any) -> Dict[str, Any]:
+    """Wrap an LLM-derived value as a hypothesis so it is never bare."""
+    return {"v": value, "src": GUESS}
+
+
+def _api_basename(name: str) -> str:
+    return (name or "").split(".")[-1].lower()
+
+
+class _Builder:
+    """Walks one analysed XRefer instance into the anatomy dict."""
+
+    def __init__(self, x: Any):
+        self.x = x
+        self.ib: int = int(x.image_base)
+        self.ep: Optional[int] = x.current_analysis_ep
+        self.ca: Dict[str, Any] = getattr(x, "cluster_analysis", None) or {}
+        self.entities = x.entities
+        self.gx = x.global_xrefs
+        self.DIRECT = x.DIRECT_XREFS
+        self.INDIRECT = x.INDIRECT_XREFS
+        try:
+            self.placements = x.classify_functions()
+        except Exception as e:  # pragma: no cover - defensive
+            log(f"[agent_map] classify_functions failed ({e}); origin left best-effort")
+            self.placements = {}
+        # reachable-node set for orphan detection
+        self._reach_nodes: Set[int] = set()
+        if self.ep is not None:
+            for plist in (x.paths.get(self.ep, {}) or {}).values():
+                for p in plist:
+                    self._reach_nodes.update(p)
+
+    # ---------------- addressing ----------------
+    def rva(self, ea: int) -> str:
+        return f"0x{(int(ea) - self.ib) & 0xFFFFFFFFFFFFFFFF:x}"
+
+    # ---------------- per-function static ----------------
+    def _category(self, ea: int) -> str:
+        p = self.placements.get(ea)
+        return getattr(p, "category", None) or "cluster_member"
+
+    def _entry(self, ea: int, idx: int) -> Dict[str, Any]:
+        return self.gx.get(ea, {})[idx] if ea in self.gx else {}
+
+    def _indirect_count(self, ea: int) -> int:
+        try:
+            ind = self._entry(ea, self.INDIRECT)
+            return sum(len(ind.get(k, ())) for k in ("libs", "imports", "strings", "capa", "api_trace"))
+        except Exception:
+            return 0
+
+    def _direct_artifacts(self, ea: int) -> Dict[str, List[Dict[str, Any]]]:
+        out: Dict[str, List[Dict[str, Any]]] = {"apis": [], "strings": [], "libs": [], "capa": [], "api_trace": []}
+        d = self._entry(ea, self.DIRECT)
+        if not d:
+            return out
+        for setkey, eakey, outkey in (
+            ("imports", "imports_ea", "apis"), ("strings", "strings_ea", "strings"),
+            ("libs", "libs_ea", "libs"), ("capa", "capa_ea", "capa"),
+            ("api_trace", "api_trace_ea", "api_trace"),
+        ):
+            for idx in sorted(d.get(setkey, ())):
+                try:
+                    name = self.entities[idx][1]
+                except Exception:
+                    name = str(idx)
+                sites = sorted(self.rva(a) for a in d.get(eakey, {}).get(idx, ()))
+                out[outkey].append({"entity_idx": idx, "name": name, "call_site_rvas": sites})
+        return {k: v for k, v in out.items() if v}
+
+    # ---------------- cluster-level static ----------------
+    def _import_basenames(self, cluster: Any) -> Set[str]:
+        names: Set[str] = set()
+        for ea in cluster.nodes:
+            for xt in (self.DIRECT, self.INDIRECT):
+                for idx in self._entry(ea, xt).get("imports", ()):
+                    try:
+                        names.add(_api_basename(self.entities[idx][1]))
+                    except Exception:
+                        pass
+        return names
+
+    def _danger_floor(self, cluster: Any) -> Optional[str]:
+        names = self._import_basenames(cluster)
+        for cat, sig in DANGER_FLOOR.items():
+            if names & sig:
+                return cat
+        return None
+
+    def _static_lib(self, cluster: Any) -> bool:
+        nodes = list(cluster.nodes)
+        return bool(nodes) and all(self._category(ea) == "func_lib" for ea in nodes)
+
+    def _reachability(self, root_ea: int) -> Dict[str, Any]:
+        plist = (self.x.paths.get(self.ep, {}) or {}).get(root_ea) if self.ep is not None else None
+        if not plist:
+            return {"reachable": False, "min_depth": None, "via_path_rvas": [], "n_paths": 0}
+        shortest = min(plist, key=len)
+        return {
+            "reachable": True, "min_depth": len(shortest) - 1,
+            "via_path_rvas": [self.rva(e) for e in shortest], "n_paths": len(plist),
+        }
+
+    def _cluster_static(self, cluster: Any) -> Dict[str, Any]:
+        funcs = []
+        for ea in sorted(cluster.nodes):
+            arts = self._direct_artifacts(ea)
+            funcs.append({
+                "rva": self.rva(ea),
+                "category": self._category(ea),
+                "is_simple_api_thunk": self._safe_thunk(ea),
+                "indirect_artifact_count": self._indirect_count(ea),
+                "artifacts": arts,
+            })
+        edges = [[self.rva(s), self.rva(t)] for (s, t) in getattr(cluster, "edges", [])]
+        subrefs = [{"at_node_rva": self.rva(n), "child_cluster_id": cid}
+                   for n, cid in getattr(cluster, "cluster_refs", {}).items()]
+        return {"functions": funcs, "edges": edges, "subcluster_refs": subrefs}
+
+    def _safe_thunk(self, ea: int) -> bool:
+        try:
+            return bool(self.x.is_simple_api_thunk(ea))
+        except Exception:
+            return False
+
+    # ---------------- LLM overlay ----------------
+    def _cluster_llm(self, cluster: Any) -> Optional[Dict[str, Any]]:
+        analysis = find_cluster_analysis(self.ca, cluster.id) if self.ca else None
+        if not analysis:
+            return None
+        get = (lambda k: analysis.get(k)) if isinstance(analysis, dict) else (lambda k: getattr(analysis, k, None))
+        raw_mitre = get("mitre_attack") or []
+        mitre = []
+        for e in raw_mitre:
+            ed = e.model_dump() if hasattr(e, "model_dump") else (e if isinstance(e, dict) else None)
+            if not ed or not ed.get("id"):
+                continue
+            mitre.append({"id": str(ed.get("id", "")), "tactic": str(ed.get("tactic", "")),
+                          "name": str(ed.get("name", "")), "rationale": str(ed.get("rationale", ""))})
+        # verify_against RVAs come from the STATIC side (cluster members), never the prose.
+        va = [self.rva(ea) for ea in sorted(cluster.nodes)][:6]
+        return {
+            "provenance": "llm",
+            "label": get("label"),
+            "description": get("description"),
+            "function_prefix": get("function_prefix"),
+            "relationships": get("relationships"),
+            "mitre": mitre,
+            "verify_against": {"key_function_rvas": va},
+            "verify": "Confirm by r2_decompile'ing the key_function_rvas at their call_site_rvas before citing.",
+        }
+
+    # ---------------- assembly ----------------
+    def build(self) -> Dict[str, Any]:
+        has_llm = bool(self.ca)
+        clusters_out: List[Dict[str, Any]] = []
+        queue: List[Dict[str, Any]] = []
+        omitted_notable: List[Dict[str, Any]] = []
+        static_lib_roots: List[str] = []
+        llm_lib_demoted: List[Dict[str, Any]] = []
+        promoted_out: List[str] = []
+
+        # rank all top-level + sub clusters flat by static score, then cap.
+        all_clusters = list(self._iter_clusters())
+        scored = []
+        for cl in all_clusters:
+            static_lib = self._static_lib(cl)
+            danger = self._danger_floor(cl)
+            llm_lib = bool(getattr(cl, "is_library", False)) and not static_lib
+            score, why = self._score(cl, danger)
+            scored.append((score, cl, static_lib, llm_lib, danger, why))
+        scored.sort(key=lambda t: t[0], reverse=True)
+
+        shown = 0
+        for score, cl, static_lib, llm_lib, danger, why in scored:
+            root_rva = self.rva(cl.root_node)
+            # library handling
+            if static_lib and danger is None:
+                static_lib_roots.append(root_rva)
+                continue
+            if llm_lib and danger is None:
+                llm_lib_demoted.append({"root_rva": root_rva,
+                                        "reason": _llm(True),
+                                        "note": "LLM library_or_runtime guess; you MAY skip to save budget but it is NOT triaged."})
+                continue
+            promoted = (static_lib or llm_lib) and danger is not None
+            if promoted:
+                promoted_out.append(root_rva)
+            # cap: signal clusters beyond MAX go to the omission ledger (danger-floor ones flagged)
+            if shown >= MAX_SIGNAL_CLUSTERS:
+                if danger is not None:
+                    omitted_notable.append({"rva": root_rva, "why": f"truncated; statically reaches danger floor: {danger}", "static": True})
+                continue
+            shown += 1
+            node = {
+                "root_rva": root_rva,
+                "run_ref": f"cluster.id.{cl.id_str}",
+                "parent_cluster_id": cl.parent_cluster_id,
+                "static_lib": static_lib,
+                "llm_lib": _llm(True) if llm_lib else None,
+                "danger_floor": danger,
+                "promoted_from_noise": promoted or None,
+                "static": self._cluster_static(cl),
+                "reachability": self._reachability(cl.root_node),
+                "llm": self._cluster_llm(cl) if has_llm else None,
+            }
+            clusters_out.append(node)
+            queue.append({
+                "kind": "cluster", "ref_rva": root_rva, "static_score": round(score, 3),
+                "danger_floor": danger, "promoted_from_noise": promoted or None,
+                "why": why, "first_move": f"r2_decompile {root_rva}", "done": False,
+            })
+
+        queue.sort(key=lambda q: q["static_score"], reverse=True)
+        for i, q in enumerate(queue, 1):
+            q["rank"] = i
+
+        data: Dict[str, Any] = {
+            "_readme": self._readme(len(clusters_out), len(all_clusters), len(static_lib_roots), len(llm_lib_demoted)),
+            "meta": {"generator": "xrefer", "schema_version": SCHEMA_VERSION, "has_llm_layer": has_llm,
+                     "target_workflow": "format_binary (persistent radare2 project, sha256-keyed)"},
+            "bind_check": self._bind_check(),
+            "image": {"format": getattr(self.x.lang, "format", None) if getattr(self.x, "lang", None) else None,
+                      "image_base": f"0x{self.ib:x}",
+                      "entry_points_rva": [self.rva(self.ep)] if self.ep is not None else []},
+            "entry_anchor": {"application_roots_rva": [c["root_rva"] for c in clusters_out[:5]],
+                             "read_first_rva": [queue[0]["ref_rva"]] if queue else []},
+            "verdict": {"claim": {"v": self.ca.get("binary_category") if has_llm else None, "src": GUESS,
+                                  "verdict": None,
+                                  "description": _llm(self.ca.get("binary_description")) if has_llm else None}},
+            "investigation_queue": queue,
+            "clusters": clusters_out,
+            "noise": {"static_lib_count": len(static_lib_roots),
+                      "static_lib_sample_rvas": static_lib_roots[:3],
+                      "llm_lib_demoted": llm_lib_demoted, "promoted_out": promoted_out},
+            "coverage": {"omitted": {"clusters": max(0, len(all_clusters) - len(clusters_out) - len(static_lib_roots) - len(llm_lib_demoted)),
+                                     "notable_rvas": omitted_notable,
+                                     "note": "You may NOT conclude 'benign'/'complete' until every notable_rva is r2-triaged."}},
+            "entities": self._entities_catalog(),
+            "report_scaffold": self._report_scaffold(),
+            "_end": {"sentinel": SENTINEL, "declared_bytes": 0, "part": "1/1"},
+        }
+        return data
+
+    def _iter_clusters(self):
+        stack = list(self.x.clusters or [])
+        while stack:
+            c = stack.pop()
+            yield c
+            stack.extend(getattr(c, "subclusters", []) or [])
+
+    def _score(self, cluster: Any, danger: Optional[str]):
+        why: List[str] = []
+        score = 0.0
+        if danger:
+            score += 3.0
+            why.append(f"reaches danger floor: {danger}")
+        # capa density
+        capa = 0
+        max_ind = 0
+        for ea in cluster.nodes:
+            capa += len(self._entry(ea, self.DIRECT).get("capa", ()))
+            max_ind = max(max_ind, self._indirect_count(ea))
+        if capa:
+            score += 0.5 * capa
+            why.append(f"{capa} capa match(es)")
+        if max_ind:
+            score += min(max_ind, 60) / 60.0
+            why.append(f"INDIRECT-hub: gates up to {max_ind} downstream artifacts")
+        reach = self._reachability(cluster.root_node)
+        if reach["reachable"]:
+            score += 1.0
+            score += max(0.0, (10 - (reach["min_depth"] or 0))) / 20.0
+            why.append(f"reachable from entry at depth {reach['min_depth']}")
+        else:
+            why.append("not reachable from entry (orphan-like)")
+        return score, why
+
+    def _entities_catalog(self) -> List[Dict[str, Any]]:
+        out = []
+        for idx, ent in enumerate(self.entities):
+            try:
+                name, type_id = ent[1], ent[2]
+            except Exception:
+                continue
+            kind = {1: "lib", 2: "api", 3: "string", 4: "capa", 5: "api_trace"}.get(type_id, str(type_id))
+            xc = 0
+            try:
+                xc = len(self.x.entity_xrefs.get(idx, ()))
+            except Exception:
+                pass
+            out.append({"idx": idx, "kind": kind, "name": name, "xref_count": xc})
+        return out
+
+    def _bind_check(self) -> Dict[str, Any]:
+        sha = None
+        try:
+            with open(self.x._backend.path, "rb") as fh:
+                sha = hashlib.sha256(fh.read()).hexdigest()
+        except Exception as e:
+            log(f"[agent_map] sha256 unavailable: {e}")
+        anchor_hex = None
+        try:
+            b = self.x._backend.read_bytes(self.ep, 12)
+            if b:
+                anchor_hex = bytes(b).hex()
+        except Exception:
+            pass
+        return {"sha256": sha, "image_base": f"0x{self.ib:x}", "baddr_is_assumed": True,
+                "check_anchor_rva": self.rva(self.ep) if self.ep is not None else None,
+                "expected_bytes_hex": anchor_hex,
+                "recipe": "r2_addr = r2_baddr + rva; read your real baddr, do not assume it equals image_base.",
+                "on_mismatch": "REFUSE: wrong sample or wrong base. Do not r2_decompile these RVAs or apply an annotation."}
+
+    def _readme(self, shown: int, total: int, static_lib: int, llm_lib: int) -> Dict[str, Any]:
+        return {
+            "format": "xrefer-binary-anatomy",
+            "what": ("A single-file investigation PLAN produced by xrefer. NOT a finished analysis and "
+                     "contains NO decompiled code. Ranks where to point radare2 first; xrefer's "
+                     "interpretations are null-verdict hypotheses you must confirm by reading the body."),
+            "provenance": ("BARE values = STATIC ground truth (RVAs, imports, xrefs, paths, capa, "
+                           "category=='func_lib'/is_simple_api_thunk). Objects with src=='xrefer_llm_guess' = "
+                           "HYPOTHESIS. NOTE: cluster is_library/llm_lib and per-function origin are LLM-derived; "
+                           "the static library signal is category=='func_lib'. type_id: 1=lib 2=api 3=string 4=capa 5=api_trace."),
+            "capability_gate_applies": True,
+            "counts": {"clusters_shown": shown, "clusters_total": total,
+                       "clusters_static_lib": static_lib, "clusters_llm_lib": llm_lib},
+        }
+
+    def _report_scaffold(self) -> Dict[str, Any]:
+        return {
+            "output_contract": [
+                "Emit a coverage header FIRST, computed from the functions you actually r2_decompile'd.",
+                "Every capability sentence MUST quote the decompiled body excerpt at its cited RVA.",
+                "Attribute every xrefer hypothesis ('xrefer proposed X; I confirmed via r2_decompile @RVA' or 'UNCONFIRMED').",
+                "Do NOT write 'benign'/completeness while any coverage.omitted.notable_rvas RVA is unread.",
+                "Speak MITRE technique-ids for the TTP section.",
+            ],
+        }
+
+
+def build_anatomy(xrefer: Any) -> Dict[str, Any]:
+    """Return the anatomy dict for an analysed XRefer instance."""
+    return _Builder(xrefer).build()
+
+
+def export_anatomy(xrefer: Any, out_path: str) -> str:
+    """Write the single-file anatomy JSON to ``out_path``; returns the path."""
+    data = build_anatomy(xrefer)
+    # fixed-point declared_bytes so the integrity trailer is exact
+    data["_end"]["declared_bytes"] = 0
+    raw = json.dumps(data, indent=2)
+    cur = len(raw.encode("utf-8"))
+    n = cur
+    for _ in range(6):
+        n = cur - 1 + len(str(n))
+    data["_end"]["declared_bytes"] = n
+    raw = json.dumps(data, indent=2)
+    with open(out_path, "w", encoding="utf-8") as fh:
+        fh.write(raw)
+    log(f"[agent_map] wrote {out_path} ({len(raw.encode('utf-8'))} bytes, "
+        f"{len(data['clusters'])} signal clusters, has_llm={data['meta']['has_llm_layer']})")
+    return out_path

--- a/plugins/xrefer/core/agent_map.py
+++ b/plugins/xrefer/core/agent_map.py
@@ -48,7 +48,9 @@ SCHEMA_VERSION = "2.0.0"
 _RUN_REF_RE = re.compile(r"cluster\.id\.(\d+)")
 SENTINEL = "XREFER_ANATOMY_EOF"
 GUESS = "xrefer_llm_guess"
-MAX_SIGNAL_CLUSTERS = 15    # single-file must stay pasteable; beyond this -> omission ledger / tiered bundle
+# NOTE: no cluster-count cap — every SIGNAL cluster is emitted so a ranked-low payload
+# (e.g. an embedded-crypto engine whose danger floor never fired) is never dropped. The
+# file grows with the count of real signal clusters; use the tiered bundle for huge binaries.
 MAX_FUNCS_PER_CLUSTER = 6   # curation: keep the most artifact-dense functions per cluster (+ root)
 MAX_CALL_SITES = 3          # curation: call-site RVAs kept per artifact
 MAX_ARTIFACTS_PER_TYPE = 5  # curation: apis/strings/capa/api_trace kept per function
@@ -337,7 +339,11 @@ class _Builder:
             scored.append((score, cl, static_lib, llm_lib, danger, why))
         scored.sort(key=lambda t: t[0], reverse=True)
 
-        shown = 0
+        # No cluster cap: every SIGNAL cluster is shown (only library/noise is demoted).
+        # Curation stays per-cluster (funcs/artifacts capped) so the file grows with the
+        # count of real signal clusters, not the whole 168-cluster projection — but a
+        # ranked-below-15 payload (e.g. an embedded-crypto engine whose danger floor never
+        # fired) is never silently dropped from the pasteable file.
         for score, cl, static_lib, llm_lib, danger, why in scored:
             root_rva = self.rva(cl.root_node)
             # library handling
@@ -352,12 +358,6 @@ class _Builder:
             promoted = (static_lib or llm_lib) and danger is not None
             if promoted:
                 promoted_out.append(root_rva)
-            # cap: signal clusters beyond MAX go to the omission ledger (danger-floor ones flagged)
-            if shown >= MAX_SIGNAL_CLUSTERS:
-                if danger is not None:
-                    omitted_notable.append({"rva": root_rva, "why": f"truncated; statically reaches danger floor: {danger}", "static": True})
-                continue
-            shown += 1
             node = {
                 "root_rva": root_rva,
                 "parent_cluster_id": cl.parent_cluster_id,

--- a/plugins/xrefer/core/agent_map.py
+++ b/plugins/xrefer/core/agent_map.py
@@ -302,8 +302,9 @@ class _Builder:
                 continue
             mitre.append({"id": str(ed.get("id", "")), "tactic": str(ed.get("tactic", "")),
                           "name": str(ed.get("name", "")), "rationale": str(ed.get("rationale", ""))})
-        # verify_against RVAs come from the STATIC side (cluster members), never the prose.
-        va = [self.rva(ea) for ea in sorted(cluster.nodes)][:6]
+        # verify_against = the artifact-bearing members (the functions that make the calls),
+        # from the STATIC side — never the prose, and never just the root.
+        va = self._must_read_rvas(cluster)
         return {
             "provenance": "llm",
             "label": get("label"),
@@ -312,7 +313,7 @@ class _Builder:
             "relationships": get("relationships"),
             "mitre": mitre,
             "verify_against": {"key_function_rvas": va},
-            "verify": "Confirm by r2_decompile'ing the key_function_rvas at their call_site_rvas before citing.",
+            "verify": "This cluster is not dispositioned until you r2_decompile EVERY key_function_rvas at its call_site_rvas. The root alone is not enough.",
         }
 
     # ---------------- assembly ----------------
@@ -369,10 +370,13 @@ class _Builder:
                 "llm": self._cluster_llm(cl) if has_llm else None,
             }
             clusters_out.append(node)
+            must_read = self._must_read_rvas(cl)
             queue.append({
                 "kind": "cluster", "ref_rva": root_rva, "static_score": round(score, 3),
                 "danger_floor": danger, "promoted_from_noise": promoted or None,
-                "why": why, "first_move": f"r2_decompile {root_rva}",
+                "why": why, "must_read_rvas": must_read,
+                "first_move": (f"r2_decompile {root_rva} (root) AND every must_read_rvas function at its "
+                               f"call_site_rvas — the root alone is not a disposition"),
             })
 
         queue.sort(key=lambda q: q["static_score"], reverse=True)
@@ -615,6 +619,14 @@ class _Builder:
                 out.append(ea)
         return out
 
+    def _must_read_rvas(self, cluster: Any) -> List[str]:
+        """The bounded per-cluster required-read set: the artifact-bearing member
+        functions (the ones that actually make the API calls / hold the strings),
+        not the root. Shared by verify_against (both formats) and the queue's
+        must_read_rvas so the agent's depth floor is one consistent list."""
+        bearing = [self.rva(ea) for ea in self._artifact_bearing(cluster)]
+        return bearing[:8] or [self.rva(cluster.root_node)]
+
     def _resolve_run_refs(self, text: str) -> Tuple[List[Dict[str, str]], List[str]]:
         """Extract cluster.id.NNNN tokens from an LLM relationships string and
         resolve each to a root RVA. Surfaces unresolved ids honestly."""
@@ -654,7 +666,7 @@ class _Builder:
                           "name": str(ed.get("name", "")), "rationale": str(ed.get("rationale", ""))})
         rel_str = str(get("relationships") or "").strip()
         resolved, unresolved = self._resolve_run_refs(rel_str)
-        bearing = [self.rva(ea) for ea in self._artifact_bearing(cluster)][:8] or [self.rva(cluster.root_node)]
+        bearing = self._must_read_rvas(cluster)
         key_idxs = sorted({row["entity_idx"] for k in artifacts for row in artifacts[k]})[:12]
         return {
             "provenance": "llm",
@@ -742,19 +754,23 @@ class _Builder:
         for r in records:
             if not r["signal"]:
                 continue
-            # first_move targets the cluster ROOT (the r2 jump target). The label lives
-            # once on clusters_index[]; do not duplicate it here.
+            # must_read_rvas surfaces the depth floor (the artifact-bearing members) IN the
+            # queue so the agent cannot stop at the root without opening the dossier.
+            must_read = self._must_read_rvas(r["cl"])
             items.append({
                 "kind": "cluster", "ref": r["root_rva"], "score": round(r["score"], 3),
                 "why": r["why"], "danger_floor": r["danger"], "promoted_from_noise": r["promoted"] or None,
+                "must_read_rvas": must_read,
                 "detail_ref": f"clusters/{r['root_rva']}.json",
-                "first_move": f"open clusters/{r['root_rva']}.json; r2_decompile {r['root_rva']} (the cluster root), then its static.artifacts call_site_rvas",
+                "first_move": (f"open clusters/{r['root_rva']}.json; r2_decompile {r['root_rva']} (root) AND every "
+                               f"must_read_rvas function at its call_site_rvas — the root alone is not a disposition"),
             })
         for o in orphans:
             items.append({
                 "kind": "orphan", "ref": o["func_rva"], "score": 0.5,
                 "why": ["artifact-bearing but UNREACHABLE from entry (likely callback/TLS/export)"],
                 "danger_floor": None, "promoted_from_noise": None,
+                "must_read_rvas": [o["func_rva"]],
                 "detail_ref": None, "first_move": o["next"],
             })
         items.sort(key=lambda q: q["score"], reverse=True)

--- a/plugins/xrefer/core/agent_map.py
+++ b/plugins/xrefer/core/agent_map.py
@@ -49,11 +49,11 @@ _RUN_REF_RE = re.compile(r"cluster\.id\.(\d+)")
 SENTINEL = "XREFER_ANATOMY_EOF"
 GUESS = "xrefer_llm_guess"
 # SINGLE-FILE ONLY cap on emitted signal clusters (the tiered bundle emits every cluster). Keeps the
-# pasteable file bounded; set generously (30) so a ranked-low payload — e.g. an embedded-crypto engine
-# whose danger floor never fired (typically ~#20) — still makes the file. Danger-floor clusters cut by
-# the cap are flagged in coverage.omitted.notable_rvas, and dependency_bom surfaces crypto crates
-# regardless of the cap, so the crypto-miss the removed 15-cap caused cannot recur here.
-MAX_SINGLE_FILE_CLUSTERS = 30
+# pasteable file bounded; set (21) so a ranked-low payload — e.g. an embedded-crypto engine whose danger
+# floor never fired (typically ~#20) — still makes the file. Danger-floor clusters cut by the cap are
+# flagged in coverage.omitted.notable_rvas, and dependency_bom surfaces crypto crates regardless of the
+# cap, so the crypto-miss the removed 15-cap caused cannot recur here.
+MAX_SINGLE_FILE_CLUSTERS = 21
 MAX_FUNCS_PER_CLUSTER = 6   # curation: keep the most artifact-dense functions per cluster (+ root)
 MAX_CALL_SITES = 3          # curation: call-site RVAs kept per artifact
 MAX_ARTIFACTS_PER_TYPE = 5  # curation: apis/strings/capa/api_trace kept per function

--- a/plugins/xrefer/core/agent_map.py
+++ b/plugins/xrefer/core/agent_map.py
@@ -1098,8 +1098,26 @@ def build_anatomy(xrefer: Any) -> Dict[str, Any]:
     return _Builder(xrefer).build()
 
 
+def _read_agent_skill(filename: str) -> Optional[str]:
+    """Read a packaged agent-skill markdown from ``data/agent_skills/`` (same
+    mechanism as ``data/report_tmpl.html``). Returns None if unavailable so an
+    export never fails just because the skill file is missing."""
+    try:
+        path = os.path.join(os.path.dirname(os.path.dirname(__file__)),
+                            "data", "agent_skills", filename)
+        with open(path, "r", encoding="utf-8") as fh:
+            return fh.read()
+    except Exception as e:
+        log(f"[agent_map] agent skill {filename} unavailable: {e}")
+        return None
+
+
 def export_anatomy(xrefer: Any, out_path: str) -> str:
-    """Write the single-file anatomy JSON to ``out_path``; returns the path."""
+    """Write the single-file anatomy JSON to ``out_path``; returns the path.
+
+    Also drops the ``binary_anatomy`` consumer skill next to the JSON (a
+    static, one-time-install document — the JSON itself stays a single
+    pasteable file)."""
     data = build_anatomy(xrefer)
     # Compact JSON so the single file stays chat-pasteable.
     _dump = lambda o: json.dumps(o, ensure_ascii=False, separators=(",", ":"))
@@ -1116,6 +1134,12 @@ def export_anatomy(xrefer: Any, out_path: str) -> str:
         fh.write(raw)
     log(f"[agent_map] wrote {out_path} ({len(raw.encode('utf-8'))} bytes, "
         f"{len(data['clusters'])} signal clusters, has_llm={data['meta']['has_llm_layer']})")
+    skill = _read_agent_skill("binary_anatomy.md")
+    if skill is not None:
+        skill_path = os.path.join(os.path.dirname(os.path.abspath(out_path)), "binary_anatomy.SKILL.md")
+        with open(skill_path, "w", encoding="utf-8") as fh:
+            fh.write(skill)
+        log(f"[agent_map] wrote consumer skill to {skill_path}")
     return out_path
 
 
@@ -1183,12 +1207,22 @@ def export_agent_map(xrefer: Any, out_dir: str) -> str:
         tier2.append({"path": rel, "bytes": len(raw.encode("utf-8")),
                       "load_when": "you want xrefer's LLM narrative (reference only — do NOT use as your report's spine)"})
 
+    # Ship the consumer skill inside the bundle so it is self-describing.
+    skill_present = False
+    skill = _read_agent_skill("xrefer_agent_map.md")
+    if skill is not None:
+        with open(os.path.join(out_dir, "SKILL.md"), "w", encoding="utf-8") as fh:
+            fh.write(skill)
+        skill_present = True
+
     # Finalize the manifest and write Tier-0 map.json.
     bundle["map"]["manifest"] = {
         "tier1_dir": "clusters/",
         "tier1_files": tier1_files,
         "tier2": tier2,
-        "read_order": ["map.json", "top investigation_queue items -> their detail_ref -> Step 4 r2_decompile",
+        "skill": ("SKILL.md" if skill_present else None),
+        "read_order": ["SKILL.md (how to consume this bundle)", "map.json",
+                       "top investigation_queue items -> their detail_ref -> Step 4 r2_decompile",
                        "indices/* only to run a specific pivot"],
     }
     map_path = os.path.join(out_dir, "map.json")

--- a/plugins/xrefer/core/agent_map.py
+++ b/plugins/xrefer/core/agent_map.py
@@ -359,7 +359,6 @@ class _Builder:
             shown += 1
             node = {
                 "root_rva": root_rva,
-                "run_ref": f"cluster.id.{cl.id_str}",
                 "parent_cluster_id": cl.parent_cluster_id,
                 "static_lib": static_lib,
                 "llm_lib": _llm(True) if llm_lib else None,
@@ -373,7 +372,7 @@ class _Builder:
             queue.append({
                 "kind": "cluster", "ref_rva": root_rva, "static_score": round(score, 3),
                 "danger_floor": danger, "promoted_from_noise": promoted or None,
-                "why": why, "first_move": f"r2_decompile {root_rva}", "done": False,
+                "why": why, "first_move": f"r2_decompile {root_rva}",
             })
 
         queue.sort(key=lambda q: q["static_score"], reverse=True)
@@ -391,8 +390,7 @@ class _Builder:
             "entry_anchor": {"application_roots_rva": [c["root_rva"] for c in clusters_out[:5]],
                              "read_first_rva": [queue[0]["ref_rva"]] if queue else []},
             "verdict": {"claim": {"v": self.ca.get("binary_category") if has_llm else None, "src": GUESS,
-                                  "verdict": None,
-                                  "description": _llm(self.ca.get("binary_description")) if has_llm else None}},
+                                  "verdict": None}},
             "investigation_queue": queue,
             "clusters": clusters_out,
             "noise": {"static_lib_count": len(static_lib_roots),
@@ -682,13 +680,11 @@ class _Builder:
             child_root = self._id_to_root.get(child_id)
             subrefs.append({
                 "at_node_rva": self.rva(node_ea),
-                "child_run_ref": f"cluster.id.{child_id:04d}",
                 "child_root_rva": self.rva(child_root) if child_root is not None else None,
-                "note": "static call linkage from FunctionalCluster.cluster_refs (trustworthy edge; not an LLM guess)",
             })
         return {
             "identity": {
-                "root_rva": rec["root_rva"], "run_ref": f"cluster.id.{cl.id_str}",
+                "root_rva": rec["root_rva"],
                 "parent_root_rva": rec["parent_root_rva"], "is_library": rec["is_lib"],
                 "library_kind": rec["library_kind"], "danger_floor": rec["danger"],
                 "promoted_from_noise": rec["promoted"] or None,
@@ -729,7 +725,7 @@ class _Builder:
             llm = self._cluster_llm_full(cl, {}) if (has_llm and r["signal"]) else None
             tactics = sorted({m["tactic"] for m in (llm or {}).get("mitre", []) if m.get("tactic")}) if llm else []
             rows.append({
-                "root_rva": r["root_rva"], "run_ref": f"cluster.id.{cl.id_str}",
+                "root_rva": r["root_rva"],
                 "is_library": r["is_lib"], "library_kind": r["library_kind"],
                 "danger_floor": r["danger"], "promoted_from_noise": r["promoted"] or None,
                 "node_count": len(cl.nodes), "subcluster_count": len(getattr(cl, "subclusters", None) or []),
@@ -746,22 +742,19 @@ class _Builder:
         for r in records:
             if not r["signal"]:
                 continue
-            cl = r["cl"]
-            llm = self._cluster_llm_full(cl, {}) if has_llm else None
-            bearing = self._artifact_bearing(cl)
-            focus = self.rva(bearing[0]) if bearing else r["root_rva"]
+            # first_move targets the cluster ROOT (the r2 jump target). The label lives
+            # once on clusters_index[]; do not duplicate it here.
             items.append({
                 "kind": "cluster", "ref": r["root_rva"], "score": round(r["score"], 3),
                 "why": r["why"], "danger_floor": r["danger"], "promoted_from_noise": r["promoted"] or None,
-                "one_line": ({"provenance": "llm", "text": (llm or {}).get("label")} if llm and (llm or {}).get("label") else None),
                 "detail_ref": f"clusters/{r['root_rva']}.json",
-                "first_move": f"open clusters/{r['root_rva']}.json; r2_decompile {focus} at its static.artifacts call_site_rvas",
+                "first_move": f"open clusters/{r['root_rva']}.json; r2_decompile {r['root_rva']} (the cluster root), then its static.artifacts call_site_rvas",
             })
         for o in orphans:
             items.append({
                 "kind": "orphan", "ref": o["func_rva"], "score": 0.5,
                 "why": ["artifact-bearing but UNREACHABLE from entry (likely callback/TLS/export)"],
-                "danger_floor": None, "promoted_from_noise": None, "one_line": None,
+                "danger_floor": None, "promoted_from_noise": None,
                 "detail_ref": None, "first_move": o["next"],
             })
         items.sort(key=lambda q: q["score"], reverse=True)
@@ -786,21 +779,17 @@ class _Builder:
                 order_index = len(MITRE_TACTIC_ORDER)
             techs = []
             for t in group.techniques:
-                groundings, resolved = [], []
+                groundings = []
                 for g in t.groundings:
                     root = self._id_to_root.get(g.cluster_id)
                     rrva = self.rva(root) if root is not None else None
-                    groundings.append({"cluster_root_rva": rrva, "cluster_label": g.cluster_label, "rationale": g.rationale})
-                    if rrva:
-                        resolved.append(rrva)
+                    # cluster_root_rva is the verify pointer (resolve the label via clusters_index).
+                    groundings.append({"cluster_root_rva": rrva, "rationale": g.rationale})
                 techs.append({"id": t.id, "name": t.name, "url": mitre_attack_url(t.id),
-                              "groundings": groundings, "cluster_root_rvas": sorted(set(resolved))})
+                              "groundings": groundings})
             tactics.append({"tactic": group.tactic, "order_index": order_index, "techniques": techs})
         return {
             "provenance": "llm",
-            "verify": ("MITRE mappings are LLM-extracted; rationale is the ONLY evidence link. r2_decompile "
-                       "each grounding cluster to confirm before repeating a technique claim."),
-            "exporters_available": ["navigator", "stix", "csv"],
             "tactics_kill_chain_order": tactics,
             "empty_tactics": list(matrix.uncovered_tactics),
         }
@@ -890,8 +879,13 @@ class _Builder:
                 xc = len(self.x.entity_xrefs.get(idx, ()) or ())
             except Exception:
                 xc = 0
-            out.append({"idx": idx, "kind": kinds.get(int(type_id), str(type_id)),
-                        "group": (str(group) if group is not None else None), "name": name, "xref_count": xc})
+            kind = kinds.get(int(type_id), str(type_id))
+            row = {"idx": idx, "kind": kind, "name": name, "xref_count": xc}
+            # entity[0] is the capa NAMESPACE for capa (static, useful) but the LLM-assigned
+            # category for api/lib and "UNCATEGORIZED" for strings — keep only the static one.
+            if kind == "capa" and group is not None:
+                row["namespace"] = str(group)
+            out.append(row)
         return out
 
     def _report_md(self, has_llm: bool) -> Optional[str]:
@@ -938,14 +932,10 @@ class _Builder:
             "format": fmt,
             "bits": bits,
             "image_base_va": f"0x{self.ib:x}",
-            "join_key": "rva",
             "entry_points_rva": [self.rva(self.ep)] if self.ep is not None else [],
             "recipe": ("r2_addr = r2_baddr + rva. For a normally-mapped image r2_baddr == image_base_va. "
                        "If your r2 session is rebased (PIE/ASLR/-B), substitute your own baddr and confirm "
-                       "against one known function before trusting the rest."),
-            "note": ("sha256 is the integration key: r2_init_project keys its project by the same sha256, so a "
-                     "map is present iff it matches your sample. *_va fields are informational; *_rva fields are "
-                     "the portable join key. REFUSE to apply RVAs/annotations on a sha256 mismatch."),
+                       "against one known function. sha256 is the bind key: REFUSE to apply RVAs on a mismatch."),
         }
 
     def _provenance_legend(self) -> Dict[str, Any]:
@@ -1025,21 +1015,17 @@ class _Builder:
         functions_total = len(self.gx)
         stats = {
             "functions_total": functions_total,
-            "user_functions": functions_total - lib_funcs,
             "library_functions": lib_funcs,
             "clusters_total": len(records),
             "clusters_signal": clusters_signal,
             "clusters_library": len(records) - clusters_signal,
-            "clusters_excluded_from_tier1": len(records) - clusters_signal,
             "entities_total": len(self.entities),
             "orphan_count": len(orphans),
             "has_api_trace": any(int(self.entities[i][2]) == 5 for i in range(len(self.entities))),
             "backend_live": self._backend_live,
-            "note": ("Library/noise clusters are flagged, excluded from the queue and Tier-1 dossiers, but still "
-                     "listed in clusters_index and one fetch away. A 'library' cluster is recoverable if you "
-                     "suspect mislabeling. backend_live=false means this was a headless load-from-cache export: "
-                     "per-function has_default_name is null and category/origin come from persisted cluster "
-                     "membership (static func_lib detection needs the live backend, i.e. the in-tool export)."),
+            "backend_live_note": ("false = headless load-from-cache: has_default_name is null and "
+                                  "category/origin come from persisted membership (static func_lib detection "
+                                  "and library_functions need the live backend)."),
         }
 
         top_roots = [r["root_rva"] for r in records if r["signal"]][:5]
@@ -1050,10 +1036,6 @@ class _Builder:
                 "address_encoding": "hex-string RVA relative to image_base; see image.recipe",
                 "workflow_binding": {
                     "target_skill": "format_binary (persistent radare2 project, sha256-keyed)",
-                    "note": ("This map pre-computes format_binary Step 2 (triage) and Step 3 (indicator->code "
-                             "pivots), delivering you into Step 4 (read the bodies). It does NOT satisfy the hard "
-                             "gate: every llm value is a 'listing' hypothesis you must confirm by r2_decompile'ing "
-                             "the body before you claim it or apply an annotation."),
                     "section_to_step": {
                         "investigation_queue": "Step 2/3: your ranked shortlist of functions that matter",
                         "indices/reverse_index.json": "Step 3: precomputed r2_xrefs_to (artifact -> functions)",
@@ -1065,23 +1047,15 @@ class _Builder:
             },
             "image": self._image_block(),
             "entry_anchor": {
-                "entry_points_rva": [self.rva(self.ep)] if self.ep is not None else [],
                 "application_roots_rva": top_roots,
                 "read_first_rva": ([queue[0]["ref"]] if queue else []),
-                "runtime_note": ("Application logic lives in the signal clusters (application_roots_rva); clusters "
-                                 "flagged is_library are runtime/library. For a Go or stripped sample, read the "
-                                 "highest-scored signal roots first and treat library clusters as ignorable."),
             },
             "provenance_legend": self._provenance_legend(),
             "stats": stats,
             "binary": {
                 "provenance": "llm",
                 "category": self.ca.get("binary_category") if has_llm else None,
-                "description": self.ca.get("binary_description") if has_llm else None,
                 "report_ref": ("indices/report.md" if report_md else None),
-                "report_present": bool(report_md),
-                "verify": ("category/description are LLM verdicts. Confirm against the clusters and your own "
-                           "r2_decompile output before repeating them."),
             },
             "investigation_queue": queue,
             "clusters_index": clusters_index,
@@ -1182,7 +1156,7 @@ def export_agent_map(xrefer: Any, out_dir: str) -> str:
     for root_rva in bundle["signal_order"]:
         rel = f"clusters/{root_rva}.json"
         nbytes = _write(os.path.join(out_dir, rel), bundle["clusters"][root_rva])
-        tier1_files.append({"path": rel, "root_rva": root_rva, "bytes": nbytes})
+        tier1_files.append({"path": rel, "bytes": nbytes})
 
     # Tier-2: indices + entities + report.
     tier2: List[Dict[str, Any]] = []
@@ -1217,7 +1191,6 @@ def export_agent_map(xrefer: Any, out_dir: str) -> str:
 
     # Finalize the manifest and write Tier-0 map.json.
     bundle["map"]["manifest"] = {
-        "tier1_dir": "clusters/",
         "tier1_files": tier1_files,
         "tier2": tier2,
         "skill": ("SKILL.md" if skill_present else None),

--- a/plugins/xrefer/core/agent_map.py
+++ b/plugins/xrefer/core/agent_map.py
@@ -652,13 +652,29 @@ class _Builder:
 
     def _report_scaffold(self) -> Dict[str, Any]:
         return {
-            "output_contract": [
-                "Emit a coverage header FIRST, computed from the functions you actually r2_decompile'd.",
-                "Every capability sentence MUST quote the decompiled body excerpt at its cited RVA.",
-                "Attribute every xrefer hypothesis ('xrefer proposed X; I confirmed via r2_decompile @RVA' or 'UNCONFIRMED').",
-                "Do NOT write 'benign'/completeness while any coverage.omitted.notable_rvas RVA is unread.",
-                "Speak MITRE technique-ids for the TTP section.",
+            "deliverable": ("A standard malware analysis report in your malware_analysis format — NOT a "
+                            "verification log, disposition ledger, or coverage table. This map governs only "
+                            "WHAT you may claim and the evidence you cite for it; the report itself is the "
+                            "sections below."),
+            "sections": [
+                "executive_summary — what the sample is, its purpose, and severity, in a few sentences",
+                "identification — sha256/filename/size/format/arch + language/compiler/packer (bind_check, image)",
+                "capabilities — the core analysis, organized BY BEHAVIOR (execution, persistence, "
+                "privilege-escalation, defense-evasion, credential-access, discovery, collection, "
+                "cryptography, command-and-control, exfiltration, impact), NOT cluster by cluster",
+                "host_based_indicators — files, registry keys, mutexes, services, processes, paths",
+                "network_based_indicators — C2 endpoints, URLs, protocols, ports",
+                "mitre_attack — technique IDs mapped to the behaviors you confirmed",
+                "conclusion — overall assessment, likely family/attribution if evident, and confidence",
             ],
+            "evidence_rule": ("Write every capability and IOC in behavioral terms and carry, INLINE, the "
+                              "function RVA (at its call_site) whose decompiled body proves it — not in a "
+                              "separate table. State an xrefer hypothesis only after you confirm it in the "
+                              "body; omit or mark 'unconfirmed' anything you could not verify. Do NOT emit a "
+                              "standalone disposition ledger or coverage header — the deliverable is the report."),
+            "scope_rule": ("Investigate every investigation_queue item before you write, and do not assert "
+                           "benign-ness or completeness while any danger_floor cluster is unread — but keep "
+                           "this coverage discipline internal; it is not a report section."),
         }
 
     # =====================================================================

--- a/plugins/xrefer/core/agent_map.py
+++ b/plugins/xrefer/core/agent_map.py
@@ -956,14 +956,16 @@ class _Builder:
         return out
 
     # ---- Tier-2 index files ----
-    def _reverse_index(self) -> Dict[str, Any]:
+    def _reverse_index(self, in_scope: Set[int]) -> Dict[str, Any]:
         out: Dict[str, Any] = {
-            "_comment": ("entity_xrefs reverse index (provenance: static) = PRECOMPUTED r2_xrefs_to for every "
-                         "artifact. key = entity_idx (see entities.json); value.function_rvas = every function "
-                         "that references it. r2 address = r2_baddr + rva."),
+            "_comment": ("entity_xrefs reverse index (provenance: static) = PRECOMPUTED r2_xrefs_to, SCOPED to "
+                         "the in-scope artifacts (those cited by a signal cluster or orphan) — the ones you "
+                         "actually pivot on. key = entity_idx (see entities.json); value.function_rvas = every "
+                         "function that references it. For an out-of-scope entity, run r2_xrefs_to yourself. "
+                         "r2 address = r2_baddr + rva."),
         }
         for idx, funcs in (self.x.entity_xrefs or {}).items():
-            if not funcs:
+            if idx not in in_scope or not funcs:
                 continue
             out[str(idx)] = {"function_rvas": sorted(self.rva(ea) for ea in funcs)}
         return out
@@ -1136,8 +1138,16 @@ class _Builder:
         queue = self._investigation_queue(records, orphans, has_llm)
         clusters_index = self._clusters_index(records, has_llm)
 
+        # In-scope entities = those cited by a signal cluster (self._referenced, populated while
+        # building the dossiers above) plus anything an orphan carries. The reverse index is scoped
+        # to these — the artifacts the agent actually pivots on — instead of the whole-binary catalog;
+        # r2_xrefs_to covers any out-of-scope entity.
+        in_scope_entities: Set[int] = set(self._referenced)
+        for o in orphans:
+            in_scope_entities.update(o.get("carried_artifacts", ()))
+
         indices = {
-            "reverse_index.json": self._reverse_index(),
+            "reverse_index.json": self._reverse_index(in_scope_entities),
             "reachability.json": self._reachability_index(target_eas),
             "functions.json": self._function_index(scope_funcs, in_clusters, prefixes),
         }
@@ -1291,7 +1301,7 @@ def export_agent_map(xrefer: Any, out_dir: str) -> str:
     # Tier-2: indices + entities + report.
     tier2: List[Dict[str, Any]] = []
     _load_when = {
-        "reverse_index.json": "you need every function that references an artifact/IOC (precomputed r2_xrefs_to)",
+        "reverse_index.json": "you need every function that references an in-scope artifact/IOC (precomputed r2_xrefs_to; use r2_xrefs_to for out-of-scope)",
         "reachability.json": "you need how execution reaches a function from entry (whole-program, not an r2 call)",
         "functions.json": "you need classification or DIRECT/INDIRECT artifact counts for an in-scope function",
     }

--- a/plugins/xrefer/core/agent_map.py
+++ b/plugins/xrefer/core/agent_map.py
@@ -1173,16 +1173,7 @@ class _Builder:
                 "format": "xrefer-agent-map", "schema_version": SCHEMA_VERSION,
                 "generator": f"xrefer {_ver}", "has_llm_layer": has_llm,
                 "address_encoding": "hex-string RVA relative to image_base; see image.recipe",
-                "workflow_binding": {
-                    "target_skill": "format_binary (persistent radare2 project, sha256-keyed)",
-                    "section_to_step": {
-                        "investigation_queue": "Step 2/3: your ranked shortlist of functions that matter",
-                        "indices/reverse_index.json": "Step 3: precomputed r2_xrefs_to (artifact -> functions)",
-                        "indices/reachability.json": "Step 3: whole-program entry->function paths",
-                        "clusters/<root_rva>.json static.artifacts.call_site_rvas": "Step 4: exact addresses to r2_decompile",
-                        "clusters/<root_rva>.json llm.verify_against": "Step 4: the must-read functions to confirm the label",
-                    },
-                },
+                "target_skill": "format_binary (persistent radare2 project, sha256-keyed)",
             },
             "image": self._image_block(),
             "entry_anchor": {

--- a/plugins/xrefer/core/agent_map.py
+++ b/plugins/xrefer/core/agent_map.py
@@ -35,11 +35,17 @@ abstraction + stdlib, so it runs headless across any backend.
 
 import hashlib
 import json
-from typing import Any, Dict, List, Optional, Set
+import os
+import re
+from typing import Any, Dict, List, Optional, Set, Tuple
 
 from xrefer.core.helpers import find_cluster_analysis, log
 
 SCHEMA_VERSION = "2.0.0"
+# Cluster reference token the LLM is instructed to emit in prose relationships
+# (dspy_modules.py:633 "Always follow the format cluster.id.xxxx"). We resolve
+# these to root RVAs at export time so the agent never has to.
+_RUN_REF_RE = re.compile(r"cluster\.id\.(\d+)")
 SENTINEL = "XREFER_ANATOMY_EOF"
 GUESS = "xrefer_llm_guess"
 MAX_SIGNAL_CLUSTERS = 15    # single-file must stay pasteable; beyond this -> omission ledger / tiered bundle
@@ -107,6 +113,58 @@ class _Builder:
             for plist in (x.paths.get(self.ep, {}) or {}).values():
                 for p in plist:
                     self._reach_nodes.update(p)
+        # Resolve per-run cluster ids -> root RVA once (identity is the root; the
+        # numeric/id_str token is only resolvable at export). Covers subclusters.
+        self._id_to_root: Dict[int, int] = {}
+        self._idstr_to_root: Dict[str, int] = {}
+        for c in self._iter_clusters():
+            try:
+                self._id_to_root[c.id] = c.root_node
+                self._idstr_to_root[str(c.id_str)] = c.root_node
+            except Exception:
+                pass
+        # Function-object cache for has_default_name / name (backend-abstracted,
+        # still IDA-free — Address is a plain int subclass on the base backend).
+        self._fn_cache: Dict[int, Any] = {}
+        # Persisted-cluster fallbacks for per-function category/origin. classify_functions()
+        # (and the live backend function queries it needs) only work when the backend is
+        # fully live (in-IDA). In a headless load-from-cache export the backend can be dark,
+        # so we derive category (cluster_member vs shared) and origin (user vs library, via
+        # the LLM is_library verdict) from the persisted cluster membership — all ground
+        # truth from the .xrefer pickle. Live placements always take precedence.
+        self._member_top: Dict[int, int] = {}
+        self._member_lib_only: Dict[int, bool] = {}
+        for c in (x.clusters or []):
+            lib = bool(getattr(c, "is_library", False))
+            seen: Set[int] = set()
+            stack = [c]
+            while stack:
+                cc = stack.pop()
+                seen |= set(cc.nodes)
+                stack.extend(getattr(cc, "subclusters", None) or [])
+            for n in seen:
+                self._member_top[n] = self._member_top.get(n, 0) + 1
+                self._member_lib_only[n] = self._member_lib_only.get(n, True) and lib
+        # One-time probe: are live per-function backend queries available? They are
+        # in-IDA; a headless load-from-cache backend can be dark. Gates has_default_name
+        # (skips hundreds of doomed get_function_at calls) and is surfaced in the map so
+        # the consumer knows when this field is unavailable rather than false.
+        self._backend_live = False
+        try:
+            from xrefer.backend.base import Address
+            probe = None
+            for c in (x.clusters or []):
+                if c.nodes:
+                    probe = next(iter(c.nodes))
+                    break
+            if probe is None and self.ep is not None:
+                probe = self.ep
+            if probe is None and self.gx:
+                probe = next(iter(self.gx))
+            if probe is not None:
+                self._backend_live = self.x._backend.get_function_at(Address(int(probe))) is not None
+        except Exception:
+            self._backend_live = False
 
     # ---------------- addressing ----------------
     def rva(self, ea: int) -> str:
@@ -115,7 +173,12 @@ class _Builder:
     # ---------------- per-function static ----------------
     def _category(self, ea: int) -> str:
         p = self.placements.get(ea)
-        return getattr(p, "category", None) or "cluster_member"
+        cat = getattr(p, "category", None) if p else None
+        if cat:
+            return cat
+        # Fallback from persisted membership (func_lib needs the live backend).
+        c = self._member_top.get(ea, 0)
+        return "shared" if c >= 2 else "cluster_member"
 
     def _entry(self, ea: int, idx: int) -> Dict[str, Any]:
         return self.gx.get(ea, {})[idx] if ea in self.gx else {}
@@ -442,6 +505,593 @@ class _Builder:
             ],
         }
 
+    # =====================================================================
+    # TIERED BUNDLE ("xrefer-agent-map")
+    # ---------------------------------------------------------------------
+    # Same static-truth/llm-hypothesis discipline as the single file, but the
+    # FULL uncurated projection split across lazy-loaded files: a Tier-0
+    # map.json (verdict + ranked queue + indexes-of-everything), one Tier-1
+    # clusters/<root_rva>.json per SIGNAL cluster (full evidence incl. edges),
+    # and Tier-2 indices/ (reverse index, reachability, per-function
+    # classification, full entity catalog, LLM report). Nothing is capped —
+    # the agent fetches only what a given pivot needs.
+    # =====================================================================
+
+    # ---- per-function projections (uncapped) ----
+    def _fn(self, ea: int) -> Any:
+        """Cached backend Function object (or None). IDA-free: Address is a
+        plain int subclass on the backend abstraction."""
+        if ea in self._fn_cache:
+            return self._fn_cache[ea]
+        fn = None
+        try:
+            from xrefer.backend.base import Address
+            fn = self.x._backend.get_function_at(Address(int(ea)))
+        except Exception:
+            fn = None
+        self._fn_cache[ea] = fn
+        return fn
+
+    def _has_default_name(self, ea: int) -> Optional[bool]:
+        if not self._backend_live:
+            return None
+        fn = self._fn(ea)
+        if fn is None:
+            return None
+        try:
+            return bool(fn.has_default_name)
+        except Exception:
+            return None
+
+    def _origin(self, ea: int) -> Optional[str]:
+        p = self.placements.get(ea)
+        o = getattr(p, "origin", None) if p else None
+        if o:
+            return o
+        # Fallback: library only if EVERY containing cluster is is_library (mirrors
+        # classify_functions._origin), else user. None only for unclustered functions.
+        if ea in self._member_lib_only:
+            return "library" if self._member_lib_only[ea] else "user"
+        return None
+
+    def _func_row(self, ea: int) -> Dict[str, Any]:
+        return {
+            "rva": self.rva(ea),
+            "category": self._category(ea),
+            "origin": self._origin(ea),
+            "has_default_name": self._has_default_name(ea),
+            "is_simple_api_thunk": self._safe_thunk(ea),
+            "indirect_artifact_count": self._indirect_count(ea),
+        }
+
+    def _typed_counts(self, ea: int, xt: int) -> Dict[str, int]:
+        e = self._entry(ea, xt)
+        return {
+            "apis": len(e.get("imports", ()) or ()),
+            "strings": len(e.get("strings", ()) or ()),
+            "libs": len(e.get("libs", ()) or ()),
+            "capa": len(e.get("capa", ()) or ()),
+            "api_trace": len(e.get("api_trace", ()) or ()),
+        }
+
+    # ---- cluster-level artifacts (uncapped, merged per entity) ----
+    def _cluster_artifacts_full(self, cluster: Any) -> Dict[str, List[Dict[str, Any]]]:
+        merged: Dict[str, Dict[int, Dict[str, Any]]] = {
+            "apis": {}, "strings": {}, "libs": {}, "capa": {}, "api_trace": {},
+        }
+        for ea in cluster.nodes:
+            d = self._entry(ea, self.DIRECT)
+            if not d:
+                continue
+            for setkey, eakey, outkey in (
+                ("imports", "imports_ea", "apis"), ("strings", "strings_ea", "strings"),
+                ("libs", "libs_ea", "libs"), ("capa", "capa_ea", "capa"),
+                ("api_trace", "api_trace_ea", "api_trace"),
+            ):
+                for idx in d.get(setkey, ()):
+                    try:
+                        name = str(self.entities[idx][1])
+                    except Exception:
+                        name = str(idx)
+                    slot = merged[outkey].get(idx)
+                    if slot is None:
+                        slot = {"entity_idx": idx, "name": name, "call_site_rvas": set()}
+                        merged[outkey][idx] = slot
+                    slot["call_site_rvas"].update(self.rva(a) for a in d.get(eakey, {}).get(idx, ()))
+                    self._referenced.add(idx)
+        out: Dict[str, List[Dict[str, Any]]] = {}
+        for k, m in merged.items():
+            rows = []
+            for idx in sorted(m):
+                row = m[idx]
+                row["call_site_rvas"] = sorted(row["call_site_rvas"])
+                rows.append(row)
+            out[k] = rows
+        return out
+
+    def _artifact_bearing(self, cluster: Any) -> List[int]:
+        out = []
+        for ea in sorted(cluster.nodes):
+            d = self._entry(ea, self.DIRECT)
+            if d and any(d.get(k) for k in ("imports", "strings", "capa", "api_trace")):
+                out.append(ea)
+        return out
+
+    def _resolve_run_refs(self, text: str) -> Tuple[List[Dict[str, str]], List[str]]:
+        """Extract cluster.id.NNNN tokens from an LLM relationships string and
+        resolve each to a root RVA. Surfaces unresolved ids honestly."""
+        resolved: List[Dict[str, str]] = []
+        unresolved: List[str] = []
+        seen: Set[str] = set()
+        for m in _RUN_REF_RE.finditer(text or ""):
+            tok = m.group(1)
+            if tok in seen:
+                continue
+            seen.add(tok)
+            root = self._idstr_to_root.get(tok)
+            if root is None:
+                try:
+                    root = self._id_to_root.get(int(tok))
+                except Exception:
+                    root = None
+            run_ref = f"cluster.id.{tok}"
+            if root is None:
+                unresolved.append(run_ref)
+            else:
+                resolved.append({"run_ref": run_ref, "resolved_to_root_rva": self.rva(root)})
+        return resolved, unresolved
+
+    def _cluster_llm_full(self, cluster: Any, artifacts: Dict[str, List[Dict[str, Any]]]) -> Optional[Dict[str, Any]]:
+        analysis = find_cluster_analysis(self.ca, cluster.id) if self.ca else None
+        if not analysis:
+            return None
+        get = (lambda k: analysis.get(k)) if isinstance(analysis, dict) else (lambda k: getattr(analysis, k, None))
+        raw_mitre = get("mitre_attack") or []
+        mitre = []
+        for e in raw_mitre:
+            ed = e.model_dump() if hasattr(e, "model_dump") else (e if isinstance(e, dict) else None)
+            if not ed or not ed.get("id"):
+                continue
+            mitre.append({"id": str(ed.get("id", "")), "tactic": str(ed.get("tactic", "")),
+                          "name": str(ed.get("name", "")), "rationale": str(ed.get("rationale", ""))})
+        rel_str = str(get("relationships") or "").strip()
+        resolved, unresolved = self._resolve_run_refs(rel_str)
+        bearing = [self.rva(ea) for ea in self._artifact_bearing(cluster)][:8] or [self.rva(cluster.root_node)]
+        key_idxs = sorted({row["entity_idx"] for k in artifacts for row in artifacts[k]})[:12]
+        return {
+            "provenance": "llm",
+            "label": get("label"),
+            "description": get("description"),
+            "function_prefix": get("function_prefix"),
+            "relationships": rel_str or None,
+            "resolved_relationships": resolved,
+            "unresolved_run_ids": unresolved,
+            "mitre": mitre,
+            "verify_against": {"key_function_rvas": bearing, "key_artifact_entity_idxs": key_idxs},
+            "verify": ("r2_decompile the key_function_rvas at their static.artifacts call_site_rvas and "
+                       "confirm the behaviour in the body before citing this label or applying any rename."),
+        }
+
+    def _cluster_detail(self, rec: Dict[str, Any], has_llm: bool) -> Dict[str, Any]:
+        cl = rec["cl"]
+        artifacts = self._cluster_artifacts_full(cl)
+        funcs = [self._func_row(ea) for ea in sorted(cl.nodes)]
+        edges = sorted([[self.rva(a), self.rva(b)] for a, b in (getattr(cl, "edges", None) or [])])
+        subrefs = []
+        for node_ea, child_id in (getattr(cl, "cluster_refs", None) or {}).items():
+            child_root = self._id_to_root.get(child_id)
+            subrefs.append({
+                "at_node_rva": self.rva(node_ea),
+                "child_run_ref": f"cluster.id.{child_id:04d}",
+                "child_root_rva": self.rva(child_root) if child_root is not None else None,
+                "note": "static call linkage from FunctionalCluster.cluster_refs (trustworthy edge; not an LLM guess)",
+            })
+        return {
+            "identity": {
+                "root_rva": rec["root_rva"], "run_ref": f"cluster.id.{cl.id_str}",
+                "parent_root_rva": rec["parent_root_rva"], "is_library": rec["is_lib"],
+                "library_kind": rec["library_kind"], "danger_floor": rec["danger"],
+                "promoted_from_noise": rec["promoted"] or None,
+            },
+            "static": {"functions": funcs, "edges": edges, "subcluster_refs": subrefs, "artifacts": artifacts},
+            "llm": self._cluster_llm_full(cl, artifacts) if has_llm else None,
+        }
+
+    # ---- cluster classification (shared by index / queue / tier-1) ----
+    def _classify(self) -> List[Dict[str, Any]]:
+        records: List[Dict[str, Any]] = []
+        for cl in self._iter_clusters():
+            static_lib = self._static_lib(cl)
+            danger = self._danger_floor(cl)
+            llm_lib = bool(getattr(cl, "is_library", False)) and not static_lib
+            is_lib = static_lib or llm_lib
+            promoted = is_lib and danger is not None
+            signal = (not is_lib) or promoted
+            score, why = self._score(cl, danger)
+            pid = getattr(cl, "parent_cluster_id", None)
+            proot = self._id_to_root.get(pid) if pid is not None else None
+            records.append({
+                "cl": cl, "root_ea": cl.root_node, "root_rva": self.rva(cl.root_node),
+                "static_lib": static_lib, "llm_lib": llm_lib,
+                "library_kind": ("static" if static_lib else ("llm" if llm_lib else None)),
+                "is_lib": is_lib, "danger": danger, "promoted": promoted, "signal": signal,
+                "score": score, "why": why,
+                "parent_root_rva": self.rva(proot) if proot is not None else None,
+            })
+        records.sort(key=lambda r: r["score"], reverse=True)
+        return records
+
+    # ---- Tier-0 map.json blocks ----
+    def _clusters_index(self, records: List[Dict[str, Any]], has_llm: bool) -> List[Dict[str, Any]]:
+        rows = []
+        for r in records:
+            cl = r["cl"]
+            llm = self._cluster_llm_full(cl, {}) if (has_llm and r["signal"]) else None
+            tactics = sorted({m["tactic"] for m in (llm or {}).get("mitre", []) if m.get("tactic")}) if llm else []
+            rows.append({
+                "root_rva": r["root_rva"], "run_ref": f"cluster.id.{cl.id_str}",
+                "is_library": r["is_lib"], "library_kind": r["library_kind"],
+                "danger_floor": r["danger"], "promoted_from_noise": r["promoted"] or None,
+                "node_count": len(cl.nodes), "subcluster_count": len(getattr(cl, "subclusters", None) or []),
+                "parent_root_rva": r["parent_root_rva"],
+                "mitre_tactics": tactics,
+                "label": ({"provenance": "llm", "text": (llm or {}).get("label")} if llm and (llm or {}).get("label") else None),
+                "function_prefix": ({"provenance": "llm", "text": (llm or {}).get("function_prefix")} if llm and (llm or {}).get("function_prefix") else None),
+                "detail_ref": (f"clusters/{r['root_rva']}.json" if r["signal"] else None),
+            })
+        return rows
+
+    def _investigation_queue(self, records: List[Dict[str, Any]], orphans: List[Dict[str, Any]], has_llm: bool) -> List[Dict[str, Any]]:
+        items = []
+        for r in records:
+            if not r["signal"]:
+                continue
+            cl = r["cl"]
+            llm = self._cluster_llm_full(cl, {}) if has_llm else None
+            bearing = self._artifact_bearing(cl)
+            focus = self.rva(bearing[0]) if bearing else r["root_rva"]
+            items.append({
+                "kind": "cluster", "ref": r["root_rva"], "score": round(r["score"], 3),
+                "why": r["why"], "danger_floor": r["danger"], "promoted_from_noise": r["promoted"] or None,
+                "one_line": ({"provenance": "llm", "text": (llm or {}).get("label")} if llm and (llm or {}).get("label") else None),
+                "detail_ref": f"clusters/{r['root_rva']}.json",
+                "first_move": f"open clusters/{r['root_rva']}.json; r2_decompile {focus} at its static.artifacts call_site_rvas",
+            })
+        for o in orphans:
+            items.append({
+                "kind": "orphan", "ref": o["func_rva"], "score": 0.5,
+                "why": ["artifact-bearing but UNREACHABLE from entry (likely callback/TLS/export)"],
+                "danger_floor": None, "promoted_from_noise": None, "one_line": None,
+                "detail_ref": None, "first_move": o["next"],
+            })
+        items.sort(key=lambda q: q["score"], reverse=True)
+        for i, q in enumerate(items, 1):
+            q["rank"] = i
+        return items
+
+    def _mitre_killchain(self, has_llm: bool) -> Optional[Dict[str, Any]]:
+        if not has_llm:
+            return None
+        try:
+            from xrefer.core.mitre import (MITRE_TACTIC_ORDER, aggregate_mitre_matrix, mitre_attack_url)
+            matrix = aggregate_mitre_matrix(self.x.clusters or [], self.ca, hide_library=True)
+        except Exception as e:
+            log(f"[agent_map] mitre aggregation failed: {e}")
+            return None
+        tactics = []
+        for group in matrix.tactics:
+            try:
+                order_index = MITRE_TACTIC_ORDER.index(group.tactic)
+            except ValueError:
+                order_index = len(MITRE_TACTIC_ORDER)
+            techs = []
+            for t in group.techniques:
+                groundings, resolved = [], []
+                for g in t.groundings:
+                    root = self._id_to_root.get(g.cluster_id)
+                    rrva = self.rva(root) if root is not None else None
+                    groundings.append({"cluster_root_rva": rrva, "cluster_label": g.cluster_label, "rationale": g.rationale})
+                    if rrva:
+                        resolved.append(rrva)
+                techs.append({"id": t.id, "name": t.name, "url": mitre_attack_url(t.id),
+                              "groundings": groundings, "cluster_root_rvas": sorted(set(resolved))})
+            tactics.append({"tactic": group.tactic, "order_index": order_index, "techniques": techs})
+        return {
+            "provenance": "llm",
+            "verify": ("MITRE mappings are LLM-extracted; rationale is the ONLY evidence link. r2_decompile "
+                       "each grounding cluster to confirm before repeating a technique claim."),
+            "exporters_available": ["navigator", "stix", "csv"],
+            "tactics_kill_chain_order": tactics,
+            "empty_tactics": list(matrix.uncovered_tactics),
+        }
+
+    def _orphans_index(self) -> List[Dict[str, Any]]:
+        if self.ep is None or not self._reach_nodes:
+            return []
+        members: Set[int] = set()
+        for cl in self._iter_clusters():
+            members.update(cl.nodes)
+        out = []
+        for ea in sorted(members):
+            if ea in self._reach_nodes:
+                continue
+            d = self._entry(ea, self.DIRECT)
+            if not d:
+                continue
+            carried = sorted(set(d.get("imports", ())) | set(d.get("strings", ())) |
+                             set(d.get("capa", ())) | set(d.get("api_trace", ())))
+            if not carried:
+                continue
+            out.append({"func_rva": self.rva(ea), "carried_artifacts": carried[:20],
+                        "why": "artifact_bearing_no_entry_path",
+                        "next": f"r2_xrefs_to {self.rva(ea)} to find the caller r2's static pass missed"})
+        return out
+
+    # ---- Tier-2 index files ----
+    def _reverse_index(self) -> Dict[str, Any]:
+        out: Dict[str, Any] = {
+            "_comment": ("entity_xrefs reverse index (provenance: static) = PRECOMPUTED r2_xrefs_to for every "
+                         "artifact. key = entity_idx (see entities.json); value.function_rvas = every function "
+                         "that references it. r2 address = r2_baddr + rva."),
+        }
+        for idx, funcs in (self.x.entity_xrefs or {}).items():
+            if not funcs:
+                continue
+            out[str(idx)] = {"function_rvas": sorted(self.rva(ea) for ea in funcs)}
+        return out
+
+    def _reachability_index(self, target_eas: Set[int]) -> Dict[str, Any]:
+        out: Dict[str, Any] = {
+            "_comment": ("Distilled entry->target reachability (provenance: static). Whole-program shortest path "
+                         "from the entry point. keys = target function RVAs. shortest_path_rvas is ONE "
+                         "representative path; n_paths = how many simple paths exist. reachable:false = orphan "
+                         "(use r2_xrefs_to). r2 address = r2_baddr + rva."),
+            "entry_rva": self.rva(self.ep) if self.ep is not None else None,
+        }
+        for ea in sorted(target_eas):
+            r = self._reachability(ea)
+            out[self.rva(ea)] = {
+                "reachable": r["reachable"], "min_depth": r["min_depth"],
+                "shortest_path_rvas": r["via_path_rvas"], "n_paths": r["n_paths"],
+            }
+        return out
+
+    def _function_index(self, func_eas: Set[int], in_clusters: Dict[int, List[str]], prefixes: Dict[int, str]) -> Dict[str, Any]:
+        out: Dict[str, Any] = {
+            "_comment": ("Per-function projection (provenance: static except function_prefix = llm). Emitted ONLY "
+                         "for in-scope functions (signal clusters / orphans), never the whole binary. `indirect` = "
+                         "artifacts reachable via callees (whole-program propagation); a large indirect count marks "
+                         "a behavior-gating hub/dispatcher worth reading first. r2 address = r2_baddr + rva."),
+        }
+        for ea in sorted(func_eas):
+            row = {
+                "category": self._category(ea), "origin": self._origin(ea),
+                "has_default_name": self._has_default_name(ea), "is_simple_api_thunk": self._safe_thunk(ea),
+                "in_clusters": in_clusters.get(ea, []),
+                "direct": self._typed_counts(ea, self.DIRECT),
+                "indirect": self._typed_counts(ea, self.INDIRECT),
+            }
+            pfx = prefixes.get(ea)
+            if pfx:
+                row["function_prefix"] = {"provenance": "llm", "text": pfx}
+            out[self.rva(ea)] = row
+        return out
+
+    def _entities_catalog_full(self) -> List[Dict[str, Any]]:
+        kinds = {1: "lib", 2: "api", 3: "string", 4: "capa", 5: "api_trace"}
+        out = []
+        for idx in range(len(self.entities)):
+            try:
+                ent = self.entities[idx]
+                group, name, type_id = ent[0], ent[1], ent[2]
+            except Exception:
+                continue
+            try:
+                xc = len(self.x.entity_xrefs.get(idx, ()) or ())
+            except Exception:
+                xc = 0
+            out.append({"idx": idx, "kind": kinds.get(int(type_id), str(type_id)),
+                        "group": (str(group) if group is not None else None), "name": name, "xref_count": xc})
+        return out
+
+    def _report_md(self, has_llm: bool) -> Optional[str]:
+        if not has_llm:
+            return None
+        report = self.ca.get("binary_report") if isinstance(self.ca, dict) else None
+        if not report or str(report).strip() in ("", "No report available."):
+            return None
+        header = ("<!--\n  PROVENANCE: llm  |  REFERENCE ONLY\n"
+                  "  xrefer's LLM-authored narrative (cluster_analysis.binary_report). A Tier-2 pointer target,\n"
+                  "  never your report's spine — using its framing anchors you on xrefer's hypotheses (the\n"
+                  "  'listing is not reverse engineering' failure). Treat every claim as a lead to verify by\n"
+                  "  r2_decompile'ing the body, and cite the address/function behind each claim in your report.\n-->\n\n")
+        return header + str(report)
+
+    # ---- image / meta blocks ----
+    def _sha256(self) -> Optional[str]:
+        try:
+            return self.x._backend.binary_hash
+        except Exception:
+            pass
+        try:
+            with open(self.x._backend.path, "rb") as fh:
+                return hashlib.sha256(fh.read()).hexdigest()
+        except Exception as e:
+            log(f"[agent_map] sha256 unavailable: {e}")
+            return None
+
+    def _image_block(self) -> Dict[str, Any]:
+        path = getattr(self.x._backend, "path", None)
+        fmt = None
+        try:
+            fmt = self.x._backend.filetype()
+        except Exception:
+            pass
+        bits = None
+        for attr in ("is_64bit",):
+            v = getattr(self.x.lang, attr, None) if getattr(self.x, "lang", None) else None
+            if v is not None:
+                bits = 64 if v else 32
+        return {
+            "sha256": self._sha256(),
+            "filename": (os.path.basename(path) if path else None),
+            "format": fmt,
+            "bits": bits,
+            "image_base_va": f"0x{self.ib:x}",
+            "join_key": "rva",
+            "entry_points_rva": [self.rva(self.ep)] if self.ep is not None else [],
+            "recipe": ("r2_addr = r2_baddr + rva. For a normally-mapped image r2_baddr == image_base_va. "
+                       "If your r2 session is rebased (PIE/ASLR/-B), substitute your own baddr and confirm "
+                       "against one known function before trusting the rest."),
+            "note": ("sha256 is the integration key: r2_init_project keys its project by the same sha256, so a "
+                     "map is present iff it matches your sample. *_va fields are informational; *_rva fields are "
+                     "the portable join key. REFUSE to apply RVAs/annotations on a sha256 mismatch."),
+        }
+
+    def _provenance_legend(self) -> Dict[str, Any]:
+        return {
+            "static": "Ground truth from disassembly, imports, xrefs, execution paths, and capa. Safe to state as fact.",
+            "llm": ("A hypothesis from an LLM (cluster labels/descriptions/relationships, binary category/"
+                    "description/report, all MITRE, and the cluster library_or_runtime verdict + per-function "
+                    "origin it drives). Confirm by reading the body before citing or applying."),
+            "values": ["static", "llm"],
+            "rule": ("Filter to provenance=='static' for anything you state as fact. Every llm block names a "
+                     "verify_against pointer -> the exact function(s) to r2_decompile to confirm it."),
+            "correction": ("cluster is_library / library_kind=='llm' and per-function `origin` are LLM-DERIVED "
+                           "(they inherit the LLM library_or_runtime verdict). The genuinely-STATIC library skip "
+                           "signal is category=='func_lib' / is_simple_api_thunk / has_default_name — never skip "
+                           "a function on origin. A danger_floor cluster is force-kept even if flagged library."),
+        }
+
+    def build_bundle(self) -> Dict[str, Any]:
+        """Assemble the full tiered bundle as in-memory objects. Returns a dict
+        the exporter serializes to files: {'map', 'clusters', 'indices',
+        'entities', 'report_md', 'signal_order'}."""
+        has_llm = bool(self.ca)
+        records = self._classify()
+        orphans = self._orphans_index()
+
+        # Tier-1: one detail file per signal cluster.
+        clusters_out: Dict[str, Dict[str, Any]] = {}
+        signal_order: List[str] = []
+        prefixes: Dict[int, str] = {}
+        in_clusters: Dict[int, List[str]] = {}
+        scope_funcs: Set[int] = set()
+        for r in records:
+            cl = r["cl"]
+            for ea in cl.nodes:
+                in_clusters.setdefault(ea, [])
+                if r["root_rva"] not in in_clusters[ea]:
+                    in_clusters[ea].append(r["root_rva"])
+            if not r["signal"]:
+                continue
+            detail = self._cluster_detail(r, has_llm)
+            clusters_out[r["root_rva"]] = detail
+            signal_order.append(r["root_rva"])
+            scope_funcs.update(cl.nodes)
+            pfx = ((detail.get("llm") or {}).get("function_prefix")) if has_llm else None
+            if pfx:
+                for ea in cl.nodes:
+                    prefixes.setdefault(ea, pfx)
+
+        orphan_eas = set()
+        for o in orphans:
+            try:
+                orphan_eas.add(int(o["func_rva"], 16) + self.ib)
+            except Exception:
+                pass
+        scope_funcs |= orphan_eas
+        # Reachability targets = signal cluster roots + orphan functions.
+        target_eas = set(r["root_ea"] for r in records if r["signal"]) | orphan_eas
+
+        queue = self._investigation_queue(records, orphans, has_llm)
+        clusters_index = self._clusters_index(records, has_llm)
+
+        indices = {
+            "reverse_index.json": self._reverse_index(),
+            "reachability.json": self._reachability_index(target_eas),
+            "functions.json": self._function_index(scope_funcs, in_clusters, prefixes),
+        }
+        entities = self._entities_catalog_full()
+        report_md = self._report_md(has_llm)
+
+        try:
+            from xrefer import __version__ as _ver
+        except Exception:
+            _ver = "unknown"
+
+        clusters_signal = sum(1 for r in records if r["signal"])
+        lib_funcs = sum(1 for ea in self.gx if self._category(ea) == "func_lib")
+        functions_total = len(self.gx)
+        stats = {
+            "functions_total": functions_total,
+            "user_functions": functions_total - lib_funcs,
+            "library_functions": lib_funcs,
+            "clusters_total": len(records),
+            "clusters_signal": clusters_signal,
+            "clusters_library": len(records) - clusters_signal,
+            "clusters_excluded_from_tier1": len(records) - clusters_signal,
+            "entities_total": len(self.entities),
+            "orphan_count": len(orphans),
+            "has_api_trace": any(int(self.entities[i][2]) == 5 for i in range(len(self.entities))),
+            "backend_live": self._backend_live,
+            "note": ("Library/noise clusters are flagged, excluded from the queue and Tier-1 dossiers, but still "
+                     "listed in clusters_index and one fetch away. A 'library' cluster is recoverable if you "
+                     "suspect mislabeling. backend_live=false means this was a headless load-from-cache export: "
+                     "per-function has_default_name is null and category/origin come from persisted cluster "
+                     "membership (static func_lib detection needs the live backend, i.e. the in-tool export)."),
+        }
+
+        top_roots = [r["root_rva"] for r in records if r["signal"]][:5]
+        mp: Dict[str, Any] = {
+            "schema": {
+                "format": "xrefer-agent-map", "schema_version": SCHEMA_VERSION,
+                "generator": f"xrefer {_ver}", "has_llm_layer": has_llm,
+                "address_encoding": "hex-string RVA relative to image_base; see image.recipe",
+                "workflow_binding": {
+                    "target_skill": "format_binary (persistent radare2 project, sha256-keyed)",
+                    "note": ("This map pre-computes format_binary Step 2 (triage) and Step 3 (indicator->code "
+                             "pivots), delivering you into Step 4 (read the bodies). It does NOT satisfy the hard "
+                             "gate: every llm value is a 'listing' hypothesis you must confirm by r2_decompile'ing "
+                             "the body before you claim it or apply an annotation."),
+                    "section_to_step": {
+                        "investigation_queue": "Step 2/3: your ranked shortlist of functions that matter",
+                        "indices/reverse_index.json": "Step 3: precomputed r2_xrefs_to (artifact -> functions)",
+                        "indices/reachability.json": "Step 3: whole-program entry->function paths",
+                        "clusters/<root_rva>.json static.artifacts.call_site_rvas": "Step 4: exact addresses to r2_decompile",
+                        "clusters/<root_rva>.json llm.verify_against": "Step 4: the must-read functions to confirm the label",
+                    },
+                },
+            },
+            "image": self._image_block(),
+            "entry_anchor": {
+                "entry_points_rva": [self.rva(self.ep)] if self.ep is not None else [],
+                "application_roots_rva": top_roots,
+                "read_first_rva": ([queue[0]["ref"]] if queue else []),
+                "runtime_note": ("Application logic lives in the signal clusters (application_roots_rva); clusters "
+                                 "flagged is_library are runtime/library. For a Go or stripped sample, read the "
+                                 "highest-scored signal roots first and treat library clusters as ignorable."),
+            },
+            "provenance_legend": self._provenance_legend(),
+            "stats": stats,
+            "binary": {
+                "provenance": "llm",
+                "category": self.ca.get("binary_category") if has_llm else None,
+                "description": self.ca.get("binary_description") if has_llm else None,
+                "report_ref": ("indices/report.md" if report_md else None),
+                "report_present": bool(report_md),
+                "verify": ("category/description are LLM verdicts. Confirm against the clusters and your own "
+                           "r2_decompile output before repeating them."),
+            },
+            "investigation_queue": queue,
+            "clusters_index": clusters_index,
+            "mitre": self._mitre_killchain(has_llm),
+            "orphans_index": orphans,
+            "manifest": None,  # filled by the exporter once file sizes are known
+        }
+        return {"map": mp, "clusters": clusters_out, "indices": indices,
+                "entities": entities, "report_md": report_md, "signal_order": signal_order}
+
 
 def build_anatomy(xrefer: Any) -> Dict[str, Any]:
     """Return the anatomy dict for an analysed XRefer instance."""
@@ -467,3 +1117,85 @@ def export_anatomy(xrefer: Any, out_path: str) -> str:
     log(f"[agent_map] wrote {out_path} ({len(raw.encode('utf-8'))} bytes, "
         f"{len(data['clusters'])} signal clusters, has_llm={data['meta']['has_llm_layer']})")
     return out_path
+
+
+def build_agent_map(xrefer: Any) -> Dict[str, Any]:
+    """Return the in-memory tiered bundle for an analysed XRefer instance."""
+    return _Builder(xrefer).build_bundle()
+
+
+def export_agent_map(xrefer: Any, out_dir: str) -> str:
+    """Write the tiered ``xrefer-agent-map`` bundle under ``out_dir``.
+
+    Layout::
+
+        <out_dir>/map.json                    Tier-0 (verdict, ranked queue, indexes)
+        <out_dir>/clusters/<root_rva>.json     Tier-1 (one per signal cluster, full evidence)
+        <out_dir>/indices/reverse_index.json   Tier-2 (artifact -> functions)
+        <out_dir>/indices/reachability.json    Tier-2 (entry -> function shortest paths)
+        <out_dir>/indices/functions.json       Tier-2 (per-function classification + counts)
+        <out_dir>/indices/entities.json        Tier-2 (full artifact catalog)
+        <out_dir>/indices/report.md            Tier-2 (LLM narrative; reference only)
+
+    Tier-1/2 files are pretty-printed (lazy-loaded, human-readable, not
+    chat-pasteable). ``map.json``'s manifest is finalized last, once the
+    sizes of every other file are known. Returns the bundle directory.
+    """
+    bundle = build_agent_map(xrefer)
+    clusters_dir = os.path.join(out_dir, "clusters")
+    indices_dir = os.path.join(out_dir, "indices")
+    os.makedirs(clusters_dir, exist_ok=True)
+    os.makedirs(indices_dir, exist_ok=True)
+
+    def _write(path: str, obj: Any) -> int:
+        raw = json.dumps(obj, ensure_ascii=False, indent=2)
+        with open(path, "w", encoding="utf-8") as fh:
+            fh.write(raw)
+        return len(raw.encode("utf-8"))
+
+    # Tier-1: cluster dossiers (emitted in queue/score order).
+    tier1_files: List[Dict[str, Any]] = []
+    for root_rva in bundle["signal_order"]:
+        rel = f"clusters/{root_rva}.json"
+        nbytes = _write(os.path.join(out_dir, rel), bundle["clusters"][root_rva])
+        tier1_files.append({"path": rel, "root_rva": root_rva, "bytes": nbytes})
+
+    # Tier-2: indices + entities + report.
+    tier2: List[Dict[str, Any]] = []
+    _load_when = {
+        "reverse_index.json": "you need every function that references an artifact/IOC (precomputed r2_xrefs_to)",
+        "reachability.json": "you need how execution reaches a function from entry (whole-program, not an r2 call)",
+        "functions.json": "you need classification or DIRECT/INDIRECT artifact counts for an in-scope function",
+    }
+    for fname, obj in bundle["indices"].items():
+        rel = f"indices/{fname}"
+        nbytes = _write(os.path.join(out_dir, rel), obj)
+        tier2.append({"path": rel, "bytes": nbytes, "load_when": _load_when.get(fname, "")})
+    rel = "indices/entities.json"
+    nbytes = _write(os.path.join(out_dir, rel), bundle["entities"])
+    tier2.append({"path": rel, "bytes": nbytes,
+                  "load_when": "you need the full artifact catalog / to resolve an entity_idx to a name"})
+    if bundle["report_md"] is not None:
+        rel = "indices/report.md"
+        raw = bundle["report_md"]
+        with open(os.path.join(out_dir, rel), "w", encoding="utf-8") as fh:
+            fh.write(raw)
+        tier2.append({"path": rel, "bytes": len(raw.encode("utf-8")),
+                      "load_when": "you want xrefer's LLM narrative (reference only — do NOT use as your report's spine)"})
+
+    # Finalize the manifest and write Tier-0 map.json.
+    bundle["map"]["manifest"] = {
+        "tier1_dir": "clusters/",
+        "tier1_files": tier1_files,
+        "tier2": tier2,
+        "read_order": ["map.json", "top investigation_queue items -> their detail_ref -> Step 4 r2_decompile",
+                       "indices/* only to run a specific pivot"],
+    }
+    map_path = os.path.join(out_dir, "map.json")
+    map_bytes = _write(map_path, bundle["map"])
+
+    total = map_bytes + sum(f["bytes"] for f in tier1_files) + sum(f["bytes"] for f in tier2)
+    log(f"[agent_map] wrote tiered bundle to {out_dir}/ "
+        f"({len(tier1_files)} signal clusters, {len(tier2)} index files, {total} bytes total, "
+        f"has_llm={bundle['map']['schema']['has_llm_layer']})")
+    return out_dir

--- a/plugins/xrefer/core/analyzer.py
+++ b/plugins/xrefer/core/analyzer.py
@@ -1007,21 +1007,35 @@ class XRefer:
 
         _, _, last_edges = self._path_corpus_topology()
         for func_ea, child_func_ea in last_edges:
-            if not self.global_xrefs[child_func_ea][self.DIRECT_XREFS]["imports"]:
+            # Thunk side is only READ, so probe without creating an entry: a
+            # leaf bearing no artifacts simply has nothing to forward.
+            child_entry = self.global_xrefs.get(child_func_ea)
+            if not child_entry or not child_entry[self.DIRECT_XREFS]["imports"]:
                 continue
             fn = self._backend.get_function_at(child_func_ea)
             if not fn.is_thunk:
                 continue
-            node = next(iter(self.global_xrefs[child_func_ea][self.DIRECT_XREFS]["imports"]))
-            self.global_xrefs[func_ea][self.DIRECT_XREFS]["imports"].add(node)
+            node = next(iter(child_entry[self.DIRECT_XREFS]["imports"]))
+            # The calling side is what we WRITE to, and it is not guaranteed to
+            # have an entry yet. Entries exist for artifact-bearing functions,
+            # plus — in FULL mode only — every path node via
+            # propagate_xref_nodes(). In light mode a caller carrying no
+            # artifacts of its own therefore has none, and indexing it raised
+            # KeyError, aborting the entire analysis before clustering.
+            # Create the entry rather than skipping the forward: skipping would
+            # drop the thunk's import from the caller in light mode only, which
+            # is precisely the light/full report divergence that
+            # tests/test_light_mode_gating.py exists to prevent.
+            caller_entry = self.ensure_global_xrefs_entry(func_ea)
+            caller_entry[self.DIRECT_XREFS]["imports"].add(node)
             try:
-                if node not in self.global_xrefs[func_ea][self.DIRECT_XREFS]["imports_ea"]:
+                if node not in caller_entry[self.DIRECT_XREFS]["imports_ea"]:
                     call_xrefs = self.caller_xrefs_cache[func_ea][child_func_ea]
-                    self.global_xrefs[func_ea][self.DIRECT_XREFS]["imports_ea"][node] = call_xrefs
+                    caller_entry[self.DIRECT_XREFS]["imports_ea"][node] = call_xrefs
                     self.entity_xrefs[node].update(call_xrefs)
             except (KeyError, AttributeError) as e:
                 log(f"Warning: Failed to update thunk imports for function 0x{func_ea:x}: {e}")
-            self.global_xrefs[func_ea][self.INDIRECT_XREFS]["imports"].discard(node)
+            caller_entry[self.INDIRECT_XREFS]["imports"].discard(node)
 
     def _process_artifact_xrefs(self, idx: int, entity: Tuple, xrefs: Set[int], func_artifacts: Dict, orphan_func_artifacts: Dict, orphan_artifacts: List) -> None:
         """
@@ -2020,13 +2034,27 @@ class XRefer:
                         "[!] The entry point does not lead to any cross-references. \n"
                         "[!] Please specify a different entry point and rerun the analysis. (CLI: `--entry-point <address>`)\n\n"
                     )
+                    # Guidance, but still a run that produced no analysis: report
+                    # it as a failure so scripted/CI callers don't read the
+                    # "completed successfully" exit as a usable result.
+                    self.analysis_errors.append(
+                        f"No call paths could be generated for entry point {ep_value:#x}"
+                    )
                 else:
                     log(f"[-] Analysis aborted: {message}")
+                    # Record it: the analysis did NOT complete, so callers must
+                    # not treat this run as a success (the CLI exits non-zero on
+                    # a non-empty analysis_errors).
+                    self.analysis_errors.append(f"Analysis aborted: {message}")
             except Exception as err:
                 log(f"[-] Error running full analysis: {err}")
                 import traceback
 
                 traceback.print_exc()
+                # Without this the run aborts before clustering yet still
+                # reports "Analysis completed successfully" and exits 0, so a
+                # hard failure looks like a clean run to any caller/CI.
+                self.analysis_errors.append(f"Analysis failed: {err!r}")
 
         log_elapsed_time("Analysis Time", start_time)
 

--- a/plugins/xrefer/data/agent_skills/binary_anatomy.md
+++ b/plugins/xrefer/data/agent_skills/binary_anatomy.md
@@ -1,0 +1,141 @@
+---
+name: binary_anatomy
+description: >-
+  Consume an xrefer "binary anatomy" — a single, chat-pasteable JSON map of a native binary
+  (recognizable by _readme.format == "xrefer-binary-anatomy" and the _end.sentinel
+  "XREFER_ANATOMY_EOF"). Use it as a pre-computed investigation PLAN that ranks where to point
+  radare2 first and carries xrefer's interpretations as null-verdict hypotheses. Activate when
+  format_binary has an anatomy JSON for the sample's sha256. It never replaces reading bodies:
+  every capability claim still requires an r2_decompile. Leans on the format_binary radare2
+  toolset for all verification.
+---
+
+# binary_anatomy — consuming a single-file xrefer map
+
+## What this is (and is not)
+
+An `xrefer-binary-anatomy` JSON is a **plan**, not an analysis. It is xrefer's ranked answer to
+"where do I point radare2 first, and what do I expect to find" — plus a **hypothesis layer** you must
+burn down against r2. It carries **no decompiled code** by design, so the only material a real
+capability claim can be built from is r2 output that does not exist until you make the call. Building
+a report by quoting this paste is the "listing is not reverse engineering" failure your
+`format_binary` doctrine forbids. It fast-forwards Steps 2–3 (triage + indicator→code pivots) and
+drops you into Step 4 (read the bodies).
+
+## 0. INGEST — is the paste even intact?
+
+The JSON may arrive as chat text and can be silently clipped by a length limit. **Before parsing:**
+- Confirm the raw text ends with the `_end` block `"sentinel": "XREFER_ANATOMY_EOF"`. If it does not,
+  the paste was truncated in transit — **do not analyze a fragment; ask for a re-paste** (or the
+  tiered `xrefer-agent-map` bundle for a large binary). A mid-array clip is invalid JSON anyway.
+- `_end.declared_bytes` is the intended UTF-8 byte length; a large mismatch with what you received is
+  another truncation signal.
+- Read `_readme.counts` (`clusters_shown` / `clusters_total` / `clusters_static_lib` /
+  `clusters_llm_lib`) so you know how much of the binary this file actually covers. When
+  `clusters_shown < clusters_total`, `coverage.omitted` is authoritative about what was left out.
+
+## 1. BIND — is this anatomy actually for the sample r2 loaded? (fail-closed)
+
+`bind_check` is a hard precondition, not a courtesy:
+- `r2_init_project` the sample; read r2's **real** baddr — do NOT assume it equals
+  `bind_check.image_base` (`baddr_is_assumed` is true; ASLR/PIE/.NET break that).
+- For every RVA in this file, `r2_addr = r2_baddr + rva` (see `bind_check.recipe`).
+- **Verify sha256 first:** if `bind_check.sha256` != your sample's sha256, **REFUSE** — wrong sample.
+- If `bind_check.expected_bytes_hex` is present, probe it: `r2_get_bytes` at
+  `r2_baddr + bind_check.check_anchor_rva` and compare. On mismatch, follow `bind_check.on_mismatch`
+  — **REFUSE**: do not `r2_decompile` against these RVAs and **never `r2_rename`** (a wrong-sample
+  rename is a destructive write). (`expected_bytes_hex` may be null in headless exports; the sha256
+  check is still binding.)
+
+## 2. The two-world rule (provenance)
+
+Read `_readme.provenance`. Two kinds of value live in this file:
+- **Bare values = STATIC ground truth.** RVAs, imports/strings/capa names, `call_site_rvas`,
+  `reachability.via_path_rvas`, `entities[]`, `danger_floor`, `noise.static_lib_*`,
+  `coverage.omitted.notable_rvas`, and the static per-function skip signals `category=="func_lib"` /
+  `is_simple_api_thunk`. You may state these as fact.
+- **Any object shaped `{"v": ..., "src": "xrefer_llm_guess"}` = a HYPOTHESIS.** Every LLM value is
+  wrapped this way (the `verdict` block, each cluster's `llm` block, `llm_lib`). The `src` tag travels
+  with the value even if you lift a sub-object in isolation, so a quoted `"keylogger"` still shows it
+  is a guess. It confirms nothing until you read the body.
+- **NOT static, despite looking plain:** cluster `llm_lib` and (in the cluster `llm` block) any
+  library framing inherit the LLM `library_or_runtime` verdict. Never treat them as skip authority.
+
+## 3. The capability gate — ALWAYS applies (`_readme.capability_gate_applies` is always true)
+
+**No capability sentence in your report without a decompiled body behind it.** For each cluster's
+`llm.verify_against.key_function_rvas`, `r2_decompile` every RVA, read the body, and only then may you
+repeat the cluster's `label`/`description`/`mitre`. This holds in degraded mode too: with
+`meta.has_llm_layer == false` there are no hypotheses to confirm, but `investigation_queue[].why` and
+the static evidence are still only LEADS (where to point r2), never findings.
+
+## 4. The loop
+
+Walk `investigation_queue` — a ranked to-do list, each item's `first_move` is a literal starting r2
+call and `ref_rva` is the cluster root (= the address to `r2_decompile`). For each item:
+- Open the matching entry in `clusters[]` (match `root_rva == ref_rva`).
+- `r2_decompile` its `static.functions`, jumping to each function's `artifacts.*.call_site_rvas` (the
+  exact instructions). **Skip a function only on the STATIC signals** `category=="func_lib"` /
+  `is_simple_api_thunk` unless a lead points in. Do NOT skip on library framing from the LLM layer —
+  it can hide a mislabeled malicious function.
+- `indirect_artifact_count` on a function marks a behavior-gating hub/dispatcher — high count = read
+  it first.
+- `reachability.via_path_rvas` is one static path from entry to the root; `n_paths` is how many exist.
+- `static.subcluster_refs[].at_node_rva`→`child_cluster_id` are real call linkages (trustworthy).
+- Use `llm.verify_against.key_function_rvas` as the must-read set and `llm.mitre[].rationale` as the
+  claim to confirm. Note `static.functions_omitted` > 0 means the single file dropped low-signal
+  members of this cluster — the tiered bundle (or `r2_callees` from the root) has the rest.
+
+## 5. Anti-hiding — you cannot conclude "clean" on a curated map
+
+A single file can't hold a big binary, so clusters are curated and library-demoted. The safety net is
+**static**, not the LLM's opinion:
+- `coverage.omitted.notable_rvas` lists, by RVA, every omitted cluster that **statically** reaches a
+  danger floor (process-injection / crypto / net-exfil / cred-access imports). You **must r2-triage
+  every one** before any completeness or "benign" verdict (see `coverage.omitted.note`).
+- `noise.promoted_out`, and any queue/cluster item with `promoted_from_noise:true`, are clusters the
+  LLM called "library" but that statically reach the danger set — treat them as normal queue items.
+- `noise.static_lib_count` / `static_lib_sample_rvas` (every member hit the static FUNC_LIB/thunk
+  path) is deterministic library code, collapsed to a count — safe to skip.
+- `noise.llm_lib_demoted` (LLM `library_or_runtime` guess, `{v,src}`-tagged, NOT statically confirmed)
+  is the budget lever: you **MAY skip these to save decompiler budget** — that is their purpose — **but
+  they are visible, not triaged.** Analyze one if budget allows, a lead points into it, or it shows up
+  in `coverage.omitted.notable_rvas`. Any llm_lib cluster reaching a danger floor is already
+  force-promoted (`promoted_out`), so a payload the LLM mislabeled "library" cannot hide here. Never
+  skip on the LLM library flag when a static danger signal disagrees.
+
+## 6. OUTPUT CONTRACT (this is where the gate is enforced)
+
+Follow `report_scaffold.output_contract`. Your report is checkable by re-reading it:
+1. **First block is a coverage header**, computed from the functions you actually decompiled — e.g.
+   *"Coverage: 4 clusters confirmed via r2 / 15 shown / N omitted (unread danger-floor RVAs: none)."*
+   An agent that skipped decompiling shows "0 confirmed" and the incompleteness is visible.
+2. **Every capability sentence quotes the decompiled body excerpt at its cited RVA.** No body quote,
+   no claim.
+3. **Attribute every hypothesis:** "xrefer proposed X; I confirmed via r2_decompile @RVA" or "xrefer
+   proposed X; UNCONFIRMED" — never a bare `xrefer_llm_guess` value as fact.
+4. **No "benign"/completeness** while any `coverage.omitted.notable_rvas` RVA is unread.
+5. Speak MITRE technique-ids for the TTP section; pivot IOCs via `get_context_for_hash` /
+   `get_ioc_assessment` and drop noisy ones. List unverified xrefer hypotheses explicitly.
+
+## 7. Identity, degraded mode, anti-patterns
+
+- **Cluster identity is `root_rva`.** `run_ref` (`cluster.id.NNNN`) is run-local — never a stable key.
+  A cluster `llm.relationships` string may name other `cluster.id.NNNN`; resolve those to a root
+  yourself only via the tiered bundle's resolver — do not invent an edge from prose.
+- **Degraded (`meta.has_llm_layer:false`):** `verdict`, every cluster `llm` block, and `llm_lib`
+  collapse to null; the queue is scored purely on static signals. The static skeleton (clusters,
+  reachability, artifacts+call_site_rvas, danger_floor, coverage.omitted) is still a complete
+  Step-2/3 accelerator — proceed on structure and derive the verdict yourself.
+- Do NOT: report from the paste (any capability without a body quote); treat `noise`/omission as
+  "already triaged"; conclude "clean" with unread `notable_rvas`; use `run_ref` as a key; assume the
+  base equals `image_base`.
+
+## Fields NOT in this format (do not look for them)
+
+To keep the single file pasteable, an anatomy JSON deliberately omits: decompiled code, cluster call
+graph `edges` (recover with `r2_callees` from the root), per-function `libs` artifacts, the full
+entity catalog (`entities[]` is referenced-only), staged rename/comment suggestions, crypto
+carve-target blobs, and any binary-level prose report. When you need those, use the tiered
+`xrefer-agent-map` bundle (its `clusters/<root_rva>.json` carries edges + full artifacts, and
+`indices/` carries the reverse index, reachability, and full entity catalog).

--- a/plugins/xrefer/data/agent_skills/binary_anatomy.md
+++ b/plugins/xrefer/data/agent_skills/binary_anatomy.md
@@ -52,14 +52,42 @@ The JSON may arrive as chat text and can be silently clipped by a length limit. 
 Read `_readme.provenance`. Two kinds of value live in this file:
 - **Bare values = STATIC ground truth.** RVAs, imports/strings/capa names, `call_site_rvas`,
   `reachability.via_path_rvas`, `entities[]`, `danger_floor`, `noise.static_lib_*`,
-  `coverage.omitted.notable_rvas`, and the static per-function skip signals `category=="func_lib"` /
-  `is_simple_api_thunk`. You may state these as fact.
+  `coverage.omitted.notable_rvas`, `dependency_bom` (the crate parts list) and each function's
+  `artifacts.libs` (cluster-local crate refs), and the static per-function skip signals
+  `category=="func_lib"` / `is_simple_api_thunk`. You may state these as fact — a linked crate name
+  is a symbol-table fact, not a guess.
 - **Any object shaped `{"v": ..., "src": "xrefer_llm_guess"}` = a HYPOTHESIS.** Every LLM value is
   wrapped this way (the `verdict` block, each cluster's `llm` block, `llm_lib`). The `src` tag travels
   with the value even if you lift a sub-object in isolation, so a quoted `"keylogger"` still shows it
   is a guess. It confirms nothing until you read the body.
 - **NOT static, despite looking plain:** cluster `llm_lib` and (in the cluster `llm` block) any
   library framing inherit the LLM `library_or_runtime` verdict. Never treat them as skip authority.
+
+## 2b. The dependency BOM — the static crate parts list (crypto discipline)
+
+`dependency_bom` is a **static** inventory of the crates/libraries the binary is built from, taken from
+linked symbols — the most authoritative evidence of what primitives are actually present. Two lists:
+- **`signal`** = cluster-local crates (crypto, compression, parsers, the sample's own modules), ranked
+  most-specific first. Each row has `xrefs`, `n_clusters`, and `clusters_rva` → the exact cluster(s)
+  that use it, so a crate name pivots straight to code to read.
+- **`pervasive`** = crates spread across most clusters (language runtime / the sample's ubiquitous
+  core), listed for completeness. The split is by reference **spread**, never by a hard-coded name
+  list, so a novel or renamed crypto crate lands in `signal` like any other.
+
+**Crypto-claim discipline — this list is where the "it uses RC4" tunnel-vision failure is caught:**
+- **Report EVERY cipher/crypto crate in `signal`, not just the first or loudest one.** A ransomware
+  build routinely links several (e.g. `chacha20` + `aes` + `ctr`/`cipher` for the file encryptor and
+  `rsa` for key wrapping). Enumerate them all before you characterize the scheme.
+- **Distinguish primary vs secondary by evidence, not by xref count.** Follow each crate's
+  `clusters_rva` to the cluster, read the `must_read_rvas` bodies, and decide from behavior which cipher
+  encrypts victim data (primary) vs. wraps keys / hashes / obfuscates strings (secondary). A crate with
+  few xrefs can still be the primary bulk encryptor.
+- **A statically-linked crypto crate is EVIDENCE, not noise.** It has no CryptoAPI import to trip
+  `danger_floor`, so its cluster may rank mid-queue — do not let the ranking talk you out of it. If
+  `dependency_bom.signal` shows a cipher, the binary has that cipher; your job is to confirm *how* it is
+  used, never *whether* it is present.
+- Per-function `artifacts.libs` carries the same crate refs at the call sites inside each cluster —
+  use them to confirm the crate is invoked in the body you are reading, not merely linked.
 
 ## 3. The capability gate — ALWAYS applies (`_readme.capability_gate_applies` is always true)
 
@@ -149,8 +177,11 @@ Follow `report_scaffold.output_contract`. Your report is checkable by re-reading
 ## Fields NOT in this format (do not look for them)
 
 To keep the single file pasteable, an anatomy JSON deliberately omits: decompiled code, cluster call
-graph `edges` (recover with `r2_callees` from the root), per-function `libs` artifacts, the full
-entity catalog (`entities[]` is referenced-only), staged rename/comment suggestions, crypto
-carve-target blobs, and any binary-level prose report. When you need those, use the tiered
+graph `edges` (recover with `r2_callees` from the root), the full entity catalog (`entities[]` is
+referenced-only), staged rename/comment suggestions, crypto carve-target blobs, and any binary-level
+prose report. Per-function `artifacts.libs` and `dependency_bom` ARE present, but filtered to
+cluster-local (signal) crates — pervasive runtime crates are collapsed into `dependency_bom.pervasive`.
+When you need the omitted material or the unfiltered per-function `libs`, use the tiered
 `xrefer-agent-map` bundle (its `clusters/<root_rva>.json` carries edges + full artifacts, and
-`indices/` carries the reverse index, reachability, and full entity catalog).
+`indices/` carries the reverse index, reachability, and full entity catalog; `map.json.dependency_bom`
+mirrors this BOM with `entity_idxs`).

--- a/plugins/xrefer/data/agent_skills/binary_anatomy.md
+++ b/plugins/xrefer/data/agent_skills/binary_anatomy.md
@@ -59,10 +59,9 @@ The JSON may arrive as chat text and can be silently clipped by a length limit. 
 Read `_readme.provenance`. Two kinds of value live in this file:
 - **Bare values = STATIC ground truth.** RVAs, imports/strings/capa names, `call_site_rvas`,
   `reachability.via_path_rvas`, `entities[]`, `danger_floor`, `noise.static_lib_*`,
-  `coverage.omitted.notable_rvas`, `dependency_bom` (the crate parts list) and each function's
-  `artifacts.libs` (cluster-local crate refs), and the static per-function skip signals
-  `category=="func_lib"` / `is_simple_api_thunk`. You may state these as fact — a linked crate name
-  is a symbol-table fact, not a guess.
+  `coverage.omitted.notable_rvas`, each function's `artifacts.libs` (cluster-local crate refs), and the
+  static per-function skip signals `category=="func_lib"` / `is_simple_api_thunk`. You may state these
+  as fact — a linked crate name is a symbol-table fact, not a guess.
 - **Any object shaped `{"v": ..., "src": "xrefer_llm_guess"}` = a HYPOTHESIS.** Every LLM value is
   wrapped this way (the `verdict` block, each cluster's `llm` block, `llm_lib`). The `src` tag travels
   with the value even if you lift a sub-object in isolation, so a quoted `"keylogger"` still shows it
@@ -70,31 +69,29 @@ Read `_readme.provenance`. Two kinds of value live in this file:
 - **NOT static, despite looking plain:** cluster `llm_lib` and (in the cluster `llm` block) any
   library framing inherit the LLM `library_or_runtime` verdict. Never treat them as skip authority.
 
-## 2b. The dependency BOM — the static crate parts list (crypto discipline)
+## 2b. Per-function crate refs (`artifacts.libs`) — crypto discipline
 
-`dependency_bom` is a **static** inventory of the crates/libraries the binary is built from, taken from
-linked symbols — the most authoritative evidence of what primitives are actually present. Two lists:
-- **`signal`** = cluster-local crates (crypto, compression, parsers, the sample's own modules), ranked
-  most-specific first. Each row has `xrefs`, `n_clusters`, and `clusters_rva` → the exact cluster(s)
-  that use it, so a crate name pivots straight to code to read.
-- **`pervasive`** = crates spread across most clusters (language runtime / the sample's ubiquitous
-  core), listed for completeness. The split is by reference **spread**, never by a hard-coded name
-  list, so a novel or renamed crypto crate lands in `signal` like any other.
+Each shown cluster carries the crates its functions link, on `static.functions[].artifacts.libs` — a
+**static** list of `{entity_idx, name, call_site_rvas}` for every cluster-local crate (crypto,
+compression, parsers, the sample's own modules), at the exact call sites. Pervasive runtime crates
+(`std`/`alloc`/`core`, referenced across most clusters) are filtered out so the signal survives; the
+split is by reference **spread**, never a hard-coded name list, so a novel or renamed crypto crate is
+kept like any other. A linked crate name is symbol-table ground truth.
 
-**Crypto-claim discipline — this list is where the "it uses RC4" tunnel-vision failure is caught:**
-- **Report EVERY cipher/crypto crate in `signal`, not just the first or loudest one.** A ransomware
-  build routinely links several (e.g. `chacha20` + `aes` + `ctr`/`cipher` for the file encryptor and
-  `rsa` for key wrapping). Enumerate them all before you characterize the scheme.
-- **Distinguish primary vs secondary by evidence, not by xref count.** Follow each crate's
-  `clusters_rva` to the cluster, read the `must_read_rvas` bodies, and decide from behavior which cipher
-  encrypts victim data (primary) vs. wraps keys / hashes / obfuscates strings (secondary). A crate with
-  few xrefs can still be the primary bulk encryptor.
+**Crypto-claim discipline — this is where the "it uses RC4" tunnel-vision failure is caught:**
+- **Report EVERY cipher/crypto crate you see in `artifacts.libs`, not just the first or loudest one.** A
+  ransomware build routinely links several (e.g. `chacha20` + `aes` + `ctr`/`cipher` for the file
+  encryptor and `rsa` for key wrapping). Enumerate them all before you characterize the scheme.
+- **Distinguish primary vs secondary by evidence, not by frequency.** Read the body at each crate's
+  `call_site_rvas` and decide from behavior which cipher encrypts victim data (primary) vs. wraps keys /
+  hashes / obfuscates strings (secondary). A rarely-referenced crate can still be the primary encryptor.
 - **A statically-linked crypto crate is EVIDENCE, not noise.** It has no CryptoAPI import to trip
-  `danger_floor`, so its cluster may rank mid-queue — do not let the ranking talk you out of it. If
-  `dependency_bom.signal` shows a cipher, the binary has that cipher; your job is to confirm *how* it is
-  used, never *whether* it is present.
-- Per-function `artifacts.libs` carries the same crate refs at the call sites inside each cluster —
-  use them to confirm the crate is invoked in the body you are reading, not merely linked.
+  `danger_floor`, so its cluster may rank mid-queue — do not let the ranking talk you out of it. If a
+  cipher crate is on a function, the binary has that cipher; confirm *how* it is used, never *whether*.
+- **Coverage caveat:** `artifacts.libs` only covers the clusters this file shows (top-N by score — see
+  `_readme.counts`). A crate used only by unclustered code or a below-cap cluster will not appear here,
+  so if you suspect crypto/networking the map does not surface, confirm with `r2_imports` /
+  `r2_find_regex` against the actual binary rather than assuming absence.
 
 ## 3. The capability gate — ALWAYS applies (`_readme.capability_gate_applies` is always true)
 
@@ -178,8 +175,8 @@ evidence attached to each finding. Sections (`report_scaffold.sections`):
 - **State an xrefer hypothesis only after you confirm it in a body.** One you could not verify is either
   omitted or flagged inline as "unconfirmed" — never laundered as fact (its `xrefer_llm_guess` tag does
   not become truth by being repeated).
-- **Report ALL cryptography** from `dependency_bom` (§2b): name every cipher and say which is primary vs
-  secondary from the bodies you read; a statically-linked crypto crate is a finding, not noise.
+- **Report ALL cryptography** from the clusters' `artifacts.libs` (§2b): name every cipher and say which
+  is primary vs secondary from the bodies you read; a statically-linked crypto crate is a finding, not noise.
 - Pivot IOCs via `get_context_for_hash` / `get_ioc_assessment`; drop noisy ones.
 
 **Coverage is internal discipline, not a section:** investigate every `investigation_queue` item before
@@ -203,10 +200,10 @@ but this governs your *analysis*; it is not something you print.
 
 To keep the single file pasteable, an anatomy JSON deliberately omits: decompiled code, cluster call
 graph `edges` (recover with `r2_callees` from the root), the full entity catalog (`entities[]` is
-referenced-only), staged rename/comment suggestions, crypto carve-target blobs, and any binary-level
-prose report. Per-function `artifacts.libs` and `dependency_bom` ARE present, but filtered to
-cluster-local (signal) crates — pervasive runtime crates are collapsed into `dependency_bom.pervasive`.
-When you need the omitted material or the unfiltered per-function `libs`, use the tiered
-`xrefer-agent-map` bundle (its `clusters/<root_rva>.json` carries edges + full artifacts, and
-`indices/` carries the reverse index, reachability, and full entity catalog; `map.json.dependency_bom`
-mirrors this BOM with `entity_idxs`).
+referenced-only), staged rename/comment suggestions, crypto carve-target blobs, any binary-level prose
+report, and any binary-wide crate/dependency inventory. Per-function `artifacts.libs` IS present but
+filtered to cluster-local (signal) crates on the clusters this file shows — pervasive runtime crates are
+dropped, and crates used only by unclustered/below-cap code are not listed at all. When you need the
+omitted material or the unfiltered per-function `libs`, use the tiered `xrefer-agent-map` bundle (its
+`clusters/<root_rva>.json` carries edges + full artifacts, and `indices/` carries the reverse index,
+reachability, and full entity catalog).

--- a/plugins/xrefer/data/agent_skills/binary_anatomy.md
+++ b/plugins/xrefer/data/agent_skills/binary_anatomy.md
@@ -120,16 +120,16 @@ Follow `report_scaffold.output_contract`. Your report is checkable by re-reading
 
 ## 7. Identity, degraded mode, anti-patterns
 
-- **Cluster identity is `root_rva`.** `run_ref` (`cluster.id.NNNN`) is run-local — never a stable key.
-  A cluster `llm.relationships` string may name other `cluster.id.NNNN`; resolve those to a root
-  yourself only via the tiered bundle's resolver — do not invent an edge from prose.
+- **Cluster identity is `root_rva`.** A cluster `llm.relationships` string may name other clusters as
+  run-local `cluster.id.NNNN` tokens — never use those as stable keys, and do not invent an edge from
+  the prose; identity is always `root_rva`.
 - **Degraded (`meta.has_llm_layer:false`):** `verdict`, every cluster `llm` block, and `llm_lib`
   collapse to null; the queue is scored purely on static signals. The static skeleton (clusters,
   reachability, artifacts+call_site_rvas, danger_floor, coverage.omitted) is still a complete
   Step-2/3 accelerator — proceed on structure and derive the verdict yourself.
 - Do NOT: report from the paste (any capability without a body quote); treat `noise`/omission as
-  "already triaged"; conclude "clean" with unread `notable_rvas`; use `run_ref` as a key; assume the
-  base equals `image_base`.
+  "already triaged"; conclude "clean" with unread `notable_rvas`; use a run-local `cluster.id.NNNN`
+  token as a key; assume the base equals `image_base`.
 
 ## Fields NOT in this format (do not look for them)
 

--- a/plugins/xrefer/data/agent_skills/binary_anatomy.md
+++ b/plugins/xrefer/data/agent_skills/binary_anatomy.md
@@ -63,59 +63,74 @@ Read `_readme.provenance`. Two kinds of value live in this file:
 
 ## 3. The capability gate — ALWAYS applies (`_readme.capability_gate_applies` is always true)
 
-**No capability sentence in your report without a decompiled body behind it.** For each cluster's
-`llm.verify_against.key_function_rvas`, `r2_decompile` every RVA, read the body, and only then may you
-repeat the cluster's `label`/`description`/`mitre`. This holds in degraded mode too: with
-`meta.has_llm_layer == false` there are no hypotheses to confirm, but `investigation_queue[].why` and
-the static evidence are still only LEADS (where to point r2), never findings.
+**No capability sentence in your report without a decompiled body behind it — and that body is
+usually a cluster *member*, not the root.** Every queue item carries `must_read_rvas` (the same set as
+the cluster's `llm.verify_against.key_function_rvas`): the artifact-bearing functions that actually
+make the API calls / hold the strings. **A cluster is NOT dispositioned until you `r2_decompile` every
+one of its `must_read_rvas` at its `call_site_rvas`.** Decompiling only `ref_rva` (the root) is an
+incomplete triage — the root is frequently just a dispatcher, and the behavior lives one or more hops
+down. Only after reading the member bodies may you repeat the cluster's `label`/`description`/`mitre`.
+This holds in degraded mode too: with `meta.has_llm_layer == false` there are no hypotheses to confirm,
+but `investigation_queue[].why` and the static evidence are still only LEADS (where to point r2).
 
-## 4. The loop
+## 4. The loop — process EVERY queue item; score is order, not a skip license
 
-Walk `investigation_queue` — a ranked to-do list, each item's `first_move` is a literal starting r2
-call and `ref_rva` is the cluster root (= the address to `r2_decompile`). For each item:
-- Open the matching entry in `clusters[]` (match `root_rva == ref_rva`).
-- `r2_decompile` its `static.functions`, jumping to each function's `artifacts.*.call_site_rvas` (the
-  exact instructions). **Skip a function only on the STATIC signals** `category=="func_lib"` /
-  `is_simple_api_thunk` unless a lead points in. Do NOT skip on library framing from the LLM layer —
-  it can hide a mislabeled malicious function.
-- `indirect_artifact_count` on a function marks a behavior-gating hub/dispatcher — high count = read
-  it first.
-- `reachability.via_path_rvas` is one static path from entry to the root; `n_paths` is how many exist.
-- `static.subcluster_refs[].at_node_rva`→`child_cluster_id` are real call linkages (trustworthy).
-- Use `llm.verify_against.key_function_rvas` as the must-read set and `llm.mitre[].rationale` as the
-  claim to confirm. Note `static.functions_omitted` > 0 means the single file dropped low-signal
-  members of this cluster — the tiered bundle (or `r2_callees` from the root) has the rest.
+Walk `investigation_queue` top to bottom. **`static_score` sets the ORDER you work in; it does NOT
+license skipping.** Every queue item must end in a disposition (§6) — the queue is already xrefer's
+triaged shortlist, so an item you drop is signal you chose not to look at. For each item:
+- Open `clusters[]` (match `root_rva == ref_rva`). `r2_decompile` the root **and every
+  `must_read_rvas` function**, jumping to each function's `artifacts.*.call_site_rvas` (the exact
+  instructions). `first_move` is the ready call.
+- **Follow the behavior down the call chain — do not stop at the root.** The single file drops the
+  cluster `edges` for size and caps its member list (`static.functions_omitted > 0` says how many were
+  dropped), so recover the rest with `r2_callees` from the root and step into any child that consumes a
+  parameter you care about. Trace how the root passes data to the leaf API calls; the body that *makes*
+  the call is what proves the capability, and it is frequently a child.
+- Skip a *function inside a cluster* only on the STATIC signals `category=="func_lib"` /
+  `is_simple_api_thunk`. Never skip on LLM library framing — it can hide a mislabeled payload.
+- `indirect_artifact_count` marks a behavior-gating hub — read it first. `reachability.via_path_rvas`
+  shows how entry reaches the root (its second-to-last node is the caller = the trigger).
+  `static.subcluster_refs[].at_node_rva`→`child_cluster_id` are real call linkages.
+- Use `llm.mitre[].rationale` as the exact claim to confirm in the body.
 
-## 5. Anti-hiding — you cannot conclude "clean" on a curated map
+## 5. Anti-hiding — the budget lever is the noise ledger, NOT the queue
 
-A single file can't hold a big binary, so clusters are curated and library-demoted. The safety net is
-**static**, not the LLM's opinion:
+**Budget-saving means skipping the demoted `noise` ledger below — never an `investigation_queue`
+item.** The queue is the must-do set (§4). The `noise` block is what you are allowed to leave unread,
+and even that has a static safety net:
+- `noise.static_lib_count` / `static_lib_sample_rvas` (every member hit the static FUNC_LIB/thunk path)
+  is deterministic library code, collapsed to a count — safe to skip.
+- `noise.llm_lib_demoted` (LLM `library_or_runtime` guess, `{v,src}`-tagged, NOT statically confirmed)
+  is the actual budget lever: you **MAY leave these unread to save decompiler budget** — that is their
+  purpose — **but they are visible, not triaged.** Open one if a lead points into it or it appears in
+  `coverage.omitted.notable_rvas`.
 - `coverage.omitted.notable_rvas` lists, by RVA, every omitted cluster that **statically** reaches a
   danger floor (process-injection / crypto / net-exfil / cred-access imports). You **must r2-triage
   every one** before any completeness or "benign" verdict (see `coverage.omitted.note`).
-- `noise.promoted_out`, and any queue/cluster item with `promoted_from_noise:true`, are clusters the
-  LLM called "library" but that statically reach the danger set — treat them as normal queue items.
-- `noise.static_lib_count` / `static_lib_sample_rvas` (every member hit the static FUNC_LIB/thunk
-  path) is deterministic library code, collapsed to a count — safe to skip.
-- `noise.llm_lib_demoted` (LLM `library_or_runtime` guess, `{v,src}`-tagged, NOT statically confirmed)
-  is the budget lever: you **MAY skip these to save decompiler budget** — that is their purpose — **but
-  they are visible, not triaged.** Analyze one if budget allows, a lead points into it, or it shows up
-  in `coverage.omitted.notable_rvas`. Any llm_lib cluster reaching a danger floor is already
-  force-promoted (`promoted_out`), so a payload the LLM mislabeled "library" cannot hide here. Never
-  skip on the LLM library flag when a static danger signal disagrees.
+- `noise.promoted_out`, and any item with `promoted_from_noise:true`, are clusters the LLM called
+  "library" but that statically reach the danger set — already force-kept in the queue, so a
+  mislabeled payload cannot hide. Never skip on the LLM library flag when a static `danger_floor`
+  disagrees.
 
 ## 6. OUTPUT CONTRACT (this is where the gate is enforced)
 
 Follow `report_scaffold.output_contract`. Your report is checkable by re-reading it:
-1. **First block is a coverage header**, computed from the functions you actually decompiled — e.g.
-   *"Coverage: 4 clusters confirmed via r2 / 15 shown / N omitted (unread danger-floor RVAs: none)."*
-   An agent that skipped decompiling shows "0 confirmed" and the incompleteness is visible.
-2. **Every capability sentence quotes the decompiled body excerpt at its cited RVA.** No body quote,
-   no claim.
-3. **Attribute every hypothesis:** "xrefer proposed X; I confirmed via r2_decompile @RVA" or "xrefer
+1. **Disposition ledger FIRST — one row per `investigation_queue` item**, with a status: `confirmed`
+   (you read the root + all its `must_read_rvas`), `dismissed` (you read enough to justify it — state
+   the evidence, e.g. "root + members are statically-linked zlib"), or `blocked` (a tooling failure —
+   give the exact error and RVA). **No queue item may be silently absent.** A ledger with unexplained
+   gaps is an incomplete analysis.
+2. **Coverage header** computed from what you actually decompiled — e.g. *"12 confirmed / 2 dismissed /
+   1 blocked of 15 queued; unread danger-floor RVAs: none."*
+3. **Every capability sentence cites the specific member RVA (at its call site) whose body proves it,
+   with the decompiled excerpt** — a claim citing only the cluster root, or with no body quote, is
+   rejected.
+4. **Attribute every hypothesis:** "xrefer proposed X; I confirmed via r2_decompile @RVA" or "xrefer
    proposed X; UNCONFIRMED" — never a bare `xrefer_llm_guess` value as fact.
-4. **No "benign"/completeness** while any `coverage.omitted.notable_rvas` RVA is unread.
-5. Speak MITRE technique-ids for the TTP section; pivot IOCs via `get_context_for_hash` /
+5. **The queue is not the whole binary.** No "benign"/completeness verdict while any
+   `coverage.omitted.notable_rvas` RVA is unread, and state plainly which demoted set you did not open
+   (`_readme.counts.clusters_llm_lib` / `clusters_static_lib`).
+6. Speak MITRE technique-ids for the TTP section; pivot IOCs via `get_context_for_hash` /
    `get_ioc_assessment` and drop noisy ones. List unverified xrefer hypotheses explicitly.
 
 ## 7. Identity, degraded mode, anti-patterns

--- a/plugins/xrefer/data/agent_skills/binary_anatomy.md
+++ b/plugins/xrefer/data/agent_skills/binary_anatomy.md
@@ -3,207 +3,133 @@ name: binary_anatomy
 description: >-
   Consume an xrefer "binary anatomy" — a single, chat-pasteable JSON map of a native binary
   (recognizable by _readme.format == "xrefer-binary-anatomy" and the _end.sentinel
-  "XREFER_ANATOMY_EOF"). Use it as a pre-computed investigation PLAN that ranks where to point
-  radare2 first and carries xrefer's interpretations as null-verdict hypotheses. Activate when
-  format_binary has an anatomy JSON for the sample's sha256. It never replaces reading bodies:
-  every capability claim still requires an r2_decompile. Leans on the format_binary radare2
-  toolset for all verification.
+  "XREFER_ANATOMY_EOF"). It is a pre-computed investigation PLAN: a ranked queue of the functions
+  that matter and the exact addresses to decompile, plus xrefer's interpretations as null-verdict
+  hypotheses. Activate when format_binary has an anatomy JSON for the sample's sha256. It never
+  replaces reading bodies: every claim still requires an r2_decompile (or r2_disasm when that fails).
 ---
 
 # binary_anatomy — consuming a single-file xrefer map
 
-## Prerequisite — activate your analysis skills first
+## Prerequisite
 
-Before anything below, **confirm the `malware_analysis` and `format_binary` skills are active** in this
-session, and **activate them if they are not.** This skill only augments that workflow: `malware_analysis`
-owns the report format and the reverse-engineering doctrine, `format_binary` drives radare2, and this map
-pre-computes their triage and pivots. If those skills are unavailable, say so before proceeding.
+Confirm the **`malware_analysis`** and **`format_binary`** skills are active in this session, and
+**activate them if they are not.** This skill only augments them: `malware_analysis` owns the report
+format and RE doctrine, `format_binary` drives radare2, this map pre-computes their triage. Say so if
+they are unavailable.
 
-## What this is (and is not)
+## What this is
 
-An `xrefer-binary-anatomy` JSON is a **plan**, not an analysis. It is xrefer's ranked answer to
-"where do I point radare2 first, and what do I expect to find" — plus a **hypothesis layer** you must
-burn down against r2. It carries **no decompiled code** by design, so the only material a real
-capability claim can be built from is r2 output that does not exist until you make the call. Building
-a report by quoting this paste is the "listing is not reverse engineering" failure your
-`format_binary` doctrine forbids. It fast-forwards Steps 2–3 (triage + indicator→code pivots) and
-drops you into Step 4 (read the bodies).
+A **plan, not an analysis.** It ranks where to point radare2 first and what to expect; it carries **no
+decompiled code**. Building a report by quoting the paste is the "listing is not reverse engineering"
+failure. It fast-forwards triage and pivots and drops you into the real work: reading bodies.
 
-## 0. INGEST — is the paste even intact?
+## 1. Before you touch r2 — intact + bound (fail-closed)
 
-The JSON may arrive as chat text and can be silently clipped by a length limit. **Before parsing:**
-- Confirm the raw text ends with the `_end` block `"sentinel": "XREFER_ANATOMY_EOF"`. If it does not,
-  the paste was truncated in transit — **do not analyze a fragment; ask for a re-paste** (or the
-  tiered `xrefer-agent-map` bundle for a large binary). A mid-array clip is invalid JSON anyway.
-- `_end.declared_bytes` is the intended UTF-8 byte length; a large mismatch with what you received is
-  another truncation signal.
-- Read `_readme.counts` (`clusters_shown` / `clusters_total` / `clusters_static_lib` /
-  `clusters_llm_lib`) so you know how much of the binary this file actually covers. When
-  `clusters_shown < clusters_total`, `coverage.omitted` is authoritative about what was left out.
+- **Intact:** the raw text must end with `_end.sentinel == "XREFER_ANATOMY_EOF"`. If not, it was
+  truncated in transit — ask for a re-paste (or the tiered bundle for a big binary); do not analyze a
+  fragment. `_end.declared_bytes` is the intended byte length.
+- **Bound:** `r2_init_project` the sample and read r2's **real** baddr. **If `bind_check.sha256` != your
+  sample's sha256, REFUSE** — wrong sample. Then every address is `r2_addr = r2_baddr + rva` (do NOT
+  assume baddr == `bind_check.image_base`). If `bind_check.expected_bytes_hex` is present, probe it at
+  `r2_baddr + check_anchor_rva`; on mismatch, REFUSE — never `r2_decompile` or `r2_rename` (a
+  wrong-sample rename is a destructive write).
 
-## 1. BIND — is this anatomy actually for the sample r2 loaded? (fail-closed)
+## 2. Provenance — static is fact, llm is a hypothesis
 
-`bind_check` is a hard precondition, not a courtesy:
-- `r2_init_project` the sample; read r2's **real** baddr — do NOT assume it equals
-  `bind_check.image_base` (`baddr_is_assumed` is true; ASLR/PIE/.NET break that).
-- For every RVA in this file, `r2_addr = r2_baddr + rva` (see `bind_check.recipe`).
-- **Verify sha256 first:** if `bind_check.sha256` != your sample's sha256, **REFUSE** — wrong sample.
-- If `bind_check.expected_bytes_hex` is present, probe it: `r2_get_bytes` at
-  `r2_baddr + bind_check.check_anchor_rva` and compare. On mismatch, follow `bind_check.on_mismatch`
-  — **REFUSE**: do not `r2_decompile` against these RVAs and **never `r2_rename`** (a wrong-sample
-  rename is a destructive write). (`expected_bytes_hex` may be null in headless exports; the sha256
-  check is still binding.)
+- **Bare values = STATIC ground truth** you may state as fact: RVAs, imports/strings/capa names,
+  `call_site_rvas`, `reachability`, `danger_floor`, `artifacts.libs` (linked crate refs), and the static
+  skip signals `category=="func_lib"` / `is_simple_api_thunk`.
+- **`{"v": …, "src": "xrefer_llm_guess"}` = a HYPOTHESIS** (the `verdict`, each cluster's `llm` block,
+  `llm_lib`). It confirms nothing until you read the body. Cluster `llm_lib` and per-function `origin`
+  are LLM-derived too — never skip a function on them; the only static skip signal is `category=="func_lib"`.
 
-## 2. The two-world rule (provenance)
+## 3. THE CORE LOOP — work the queue, decompile recursively, disassemble on failure
 
-Read `_readme.provenance`. Two kinds of value live in this file:
-- **Bare values = STATIC ground truth.** RVAs, imports/strings/capa names, `call_site_rvas`,
-  `reachability.via_path_rvas`, `entities[]`, `danger_floor`, `noise.static_lib_*`,
-  `coverage.omitted.notable_rvas`, each function's `artifacts.libs` (cluster-local crate refs), and the
-  static per-function skip signals `category=="func_lib"` / `is_simple_api_thunk`. You may state these
-  as fact — a linked crate name is a symbol-table fact, not a guess.
-- **Any object shaped `{"v": ..., "src": "xrefer_llm_guess"}` = a HYPOTHESIS.** Every LLM value is
-  wrapped this way (the `verdict` block, each cluster's `llm` block, `llm_lib`). The `src` tag travels
-  with the value even if you lift a sub-object in isolation, so a quoted `"keylogger"` still shows it
-  is a guess. It confirms nothing until you read the body.
-- **NOT static, despite looking plain:** cluster `llm_lib` and (in the cluster `llm` block) any
-  library framing inherit the LLM `library_or_runtime` verdict. Never treat them as skip authority.
+This is the whole job. `investigation_queue` is xrefer's ranked shortlist; **`static_score` is the
+ORDER you work in, not a license to skip.** Take every item to a resolution (confirmed /
+dismissed-with-evidence / blocked) before you write. For each queue item:
 
-## 2b. Per-function crate refs (`artifacts.libs`) — crypto discipline
+1. **Open its cluster** in `clusters[]` (match `root_rva == ref_rva`). `first_move` is the ready call.
+2. **Decompile the root AND every `must_read_rvas`** (= the cluster's `llm.verify_against.key_function_rvas`
+   — the artifact-bearing members that actually make the calls), jumping to each function's
+   `artifacts.*.call_site_rvas`. **The root alone is never a disposition** — it is usually a dispatcher;
+   the behavior lives in a member or deeper.
+3. **Recurse down the call chain.** The single file drops cluster `edges` for size, so from each function
+   `r2_callees` and **decompile the callees too**, stepping into any child that consumes data you care
+   about — keep going until a leaf body actually *proves* the behavior. `static.functions_omitted > 0`
+   tells you members were dropped; recover them the same way. Do not stop at depth 1.
+4. **On decompile failure, disassemble.** When `r2_decompile` errors or returns garbage on a function
+   (r2ghidra can choke on obfuscated/odd code), fall back to **`r2_disasm`** for that function and read
+   the assembly; use `r2_get_bytes` / `r2_get_string` for data at a `call_site_rva`. **Never leave a
+   must-read function uncovered just because the decompiler failed** — mark it blocked only if both fail.
+5. **Skip a function only on the STATIC signals** `category=="func_lib"` / `is_simple_api_thunk`. Never
+   on LLM library framing — it can hide a mislabeled payload.
 
-Each shown cluster carries the crates its functions link, on `static.functions[].artifacts.libs` — a
-**static** list of `{entity_idx, name, call_site_rvas}` for every cluster-local crate (crypto,
-compression, parsers, the sample's own modules), at the exact call sites. Pervasive runtime crates
-(`std`/`alloc`/`core`, referenced across most clusters) are filtered out so the signal survives; the
-split is by reference **spread**, never a hard-coded name list, so a novel or renamed crypto crate is
-kept like any other. A linked crate name is symbol-table ground truth.
+**The gate:** no capability sentence in your report without a decompiled (or disassembled) body behind
+it, cited at its member RVA. Only after reading the bodies may you repeat the cluster's
+`label`/`description`/`mitre`.
 
-**Crypto-claim discipline — this is where the "it uses RC4" tunnel-vision failure is caught:**
-- **Report EVERY cipher/crypto crate you see in `artifacts.libs`, not just the first or loudest one.** A
-  ransomware build routinely links several (e.g. `chacha20` + `aes` + `ctr`/`cipher` for the file
-  encryptor and `rsa` for key wrapping). Enumerate them all before you characterize the scheme.
-- **Distinguish primary vs secondary by evidence, not by frequency.** Read the body at each crate's
-  `call_site_rvas` and decide from behavior which cipher encrypts victim data (primary) vs. wraps keys /
-  hashes / obfuscates strings (secondary). A rarely-referenced crate can still be the primary encryptor.
-- **A statically-linked crypto crate is EVIDENCE, not noise.** It has no CryptoAPI import to trip
-  `danger_floor`, so its cluster may rank mid-queue — do not let the ranking talk you out of it. If a
-  cipher crate is on a function, the binary has that cipher; confirm *how* it is used, never *whether*.
-- **Coverage caveat:** `artifacts.libs` only covers the clusters this file shows (top-N by score — see
-  `_readme.counts`). A crate used only by unclustered code or a below-cap cluster will not appear here,
-  so if you suspect crypto/networking the map does not surface, confirm with `r2_imports` /
-  `r2_find_regex` against the actual binary rather than assuming absence.
+## 4. Supporting fields — map them in as you go
 
-## 3. The capability gate — ALWAYS applies (`_readme.capability_gate_applies` is always true)
+| field | what it gives you | use it to |
+|---|---|---|
+| `investigation_queue[].must_read_rvas` | the bounded depth floor per cluster | the functions you MUST decompile |
+| `reachability.via_path_rvas` / `min_depth` | entry→root shortest path | find the trigger (second-to-last node = the caller) |
+| `danger_floor` (on a cluster/queue item) | reaches injection/crypto/net-exfil/cred-access imports | a hard must-read; never skip |
+| `indirect_artifact_count` | artifacts reachable via callees | spot the dispatcher/hub — read it first |
+| `static.subcluster_refs[]` | `at_node_rva → child_cluster_id` | real call linkages into child clusters |
+| `artifacts.libs` | linked crate refs at call sites | crypto/deps evidence (see below) |
+| `entities[]` | referenced-only catalog | resolve an `entity_idx` to a name |
+| `_readme.counts` / `coverage.omitted` | how much of the binary this file covers | see §5 |
 
-**No capability sentence in your report without a decompiled body behind it — and that body is
-usually a cluster *member*, not the root.** Every queue item carries `must_read_rvas` (the same set as
-the cluster's `llm.verify_against.key_function_rvas`): the artifact-bearing functions that actually
-make the API calls / hold the strings. **A cluster is NOT dispositioned until you `r2_decompile` every
-one of its `must_read_rvas` at its `call_site_rvas`.** Decompiling only `ref_rva` (the root) is an
-incomplete triage — the root is frequently just a dispatcher, and the behavior lives one or more hops
-down. Only after reading the member bodies may you repeat the cluster's `label`/`description`/`mitre`.
-This holds in degraded mode too: with `meta.has_llm_layer == false` there are no hypotheses to confirm,
-but `investigation_queue[].why` and the static evidence are still only LEADS (where to point r2).
+**Crypto note (anti-tunnel-vision):** when a cluster's `artifacts.libs` shows cipher crates, report
+**every** one, not just the loudest — a ransomware build routinely links several (e.g. `chacha20` +
+`aes` + `ctr` for the file encryptor, `rsa` for key wrapping). Decide primary vs secondary from the
+bodies, not from frequency. A linked crypto crate is evidence, not noise, even with a null `danger_floor`.
 
-## 4. The loop — process EVERY queue item; score is order, not a skip license
+## 5. What you may skip, and what you must not
 
-Walk `investigation_queue` top to bottom. **`static_score` sets the ORDER you work in; it does NOT
-license skipping.** Investigate every queue item to a resolution (confirmed / dismissed-with-evidence /
-blocked) before you write — this is internal coverage discipline, **not** a section you print (§6). The
-queue is already xrefer's triaged shortlist, so an item you drop is signal you chose not to look at. For
-each item:
-- Open `clusters[]` (match `root_rva == ref_rva`). `r2_decompile` the root **and every
-  `must_read_rvas` function**, jumping to each function's `artifacts.*.call_site_rvas` (the exact
-  instructions). `first_move` is the ready call.
-- **Follow the behavior down the call chain — do not stop at the root.** The single file drops the
-  cluster `edges` for size and caps its member list (`static.functions_omitted > 0` says how many were
-  dropped), so recover the rest with `r2_callees` from the root and step into any child that consumes a
-  parameter you care about. Trace how the root passes data to the leaf API calls; the body that *makes*
-  the call is what proves the capability, and it is frequently a child.
-- Skip a *function inside a cluster* only on the STATIC signals `category=="func_lib"` /
-  `is_simple_api_thunk`. Never skip on LLM library framing — it can hide a mislabeled payload.
-- `indirect_artifact_count` marks a behavior-gating hub — read it first. `reachability.via_path_rvas`
-  shows how entry reaches the root (its second-to-last node is the caller = the trigger).
-  `static.subcluster_refs[].at_node_rva`→`child_cluster_id` are real call linkages.
-- Use `llm.mitre[].rationale` as the exact claim to confirm in the body.
+- **`noise` is the only budget lever.** `noise.static_lib_*` (all members are static FUNC_LIB) is safe to
+  leave unread. `noise.llm_lib_demoted` you MAY leave unread to save budget — but it is visible, not
+  triaged; open one if a lead points into it. **Never** treat an `investigation_queue` item as skippable.
+- **`coverage.omitted.notable_rvas`** lists omitted clusters that STATICALLY reach a danger floor
+  (this file caps to the top-N by score). You **must r2-triage every one** before any "benign"/complete
+  verdict. If you suspect crypto/networking the map does not surface, confirm with `r2_imports` /
+  `r2_find_regex` — do not assume absence.
+- `promoted_from_noise:true` = a cluster the LLM called "library" that statically reaches the danger set;
+  already force-kept in the queue. Never skip on the LLM flag when a static `danger_floor` disagrees.
 
-## 5. Anti-hiding — the budget lever is the noise ledger, NOT the queue
+## 6. The deliverable — a malware analysis report (NOT a verification log)
 
-**Budget-saving means skipping the demoted `noise` ledger below — never an `investigation_queue`
-item.** The queue is the must-do set (§4). The `noise` block is what you are allowed to leave unread,
-and even that has a static safety net:
-- `noise.static_lib_count` / `static_lib_sample_rvas` (every member hit the static FUNC_LIB/thunk path)
-  is deterministic library code, collapsed to a count — safe to skip.
-- `noise.llm_lib_demoted` (LLM `library_or_runtime` guess, `{v,src}`-tagged, NOT statically confirmed)
-  is the actual budget lever: you **MAY leave these unread to save decompiler budget** — that is their
-  purpose — **but they are visible, not triaged.** Open one if a lead points into it or it appears in
-  `coverage.omitted.notable_rvas`.
-- `coverage.omitted.notable_rvas` lists, by RVA, every omitted cluster that **statically** reaches a
-  danger floor (process-injection / crypto / net-exfil / cred-access imports). You **must r2-triage
-  every one** before any completeness or "benign" verdict (see `coverage.omitted.note`).
-- `noise.promoted_out`, and any item with `promoted_from_noise:true`, are clusters the LLM called
-  "library" but that statically reach the danger set — already force-kept in the queue, so a
-  mislabeled payload cannot hide. Never skip on the LLM library flag when a static `danger_floor`
-  disagrees.
+Follow `report_scaffold`. Produce a **standard malware analysis report in your `malware_analysis`
+format** — an intelligence product, not a table of what you verified. **Do not emit a disposition
+ledger or a coverage header**; verification lives *inside* the report as the evidence attached to each
+finding. Sections (`report_scaffold.sections`): **executive summary → identification → capabilities
+(organized by behavior, not cluster) → details (a full technical walkthrough of the entire malware,
+component by component) → host-based indicators → network-based indicators → MITRE ATT&CK → conclusion.**
+- Every capability and IOC carries, inline, the **member** RVA (at its call site) whose body proves it —
+  never a bare claim, never only the cluster root.
+- State an xrefer hypothesis only after confirming it in a body; omit or mark "unconfirmed" the rest.
+- Report ALL cryptography from `artifacts.libs`; pivot IOCs via `get_context_for_hash` / `get_ioc_assessment`.
+- **Coverage is internal discipline, not a section:** cover every queue item and every
+  `coverage.omitted.notable_rvas` RVA before you write — but this governs your analysis, it is not printed.
 
-## 6. THE DELIVERABLE — a malware analysis report (NOT a verification log)
+## 7. Degraded mode & anti-patterns
 
-Follow `report_scaffold`. The output is a **standard malware analysis report in your `malware_analysis`
-format** — an intelligence product, not a table of what you verified. This map governs only *what you
-may claim and the evidence behind each claim*; it does **not** replace your report format. **Do not emit
-a disposition ledger or a coverage header** — verification is expressed *inside* the report as the
-evidence attached to each finding. Sections (`report_scaffold.sections`):
-1. **Executive summary** — what the sample is, its purpose, and severity, in a few sentences.
-2. **Identification** — sha256 / filename / size / format / arch, plus language / compiler / packer
-   (from `bind_check` + `image`).
-3. **Capabilities** — the core, organized **by behavior** (execution, persistence, privilege-escalation,
-   defense-evasion, credential-access, discovery, collection, cryptography, command-and-control,
-   exfiltration, impact) — **not cluster by cluster.** Synthesize; do not echo the map's structure.
-4. **Details** — a comprehensive technical walkthrough of the **entire** malware: its execution flow from
-   entry through every major component, covering the full binary (not only the headline behaviors), each
-   with the function RVAs and decompiled evidence behind it. This is the in-depth analysis; the
-   Capabilities section is its behavioral summary.
-5. **Host-based indicators** — files, registry keys, mutexes, services, processes, paths.
-6. **Network-based indicators** — C2 endpoints, URLs, protocols, ports.
-7. **MITRE ATT&CK** — technique-ids mapped to the behaviors you confirmed.
-8. **Conclusion** — overall assessment, likely family/attribution if evident, and your confidence.
+- **Degraded (`meta.has_llm_layer:false`):** `verdict`, every `llm` block and `llm_lib` are null; the
+  queue is scored on static signals only. The static skeleton (clusters, reachability, artifacts + call
+  sites, danger_floor, coverage.omitted) is still a complete accelerator — work the queue and derive the
+  verdict yourself.
+- **Do NOT:** report from the paste (any claim without a body); stop at a cluster root; skip a must-read
+  because the decompiler failed (disassemble instead); treat `noise`/omission as triaged; conclude
+  "clean" with unread `notable_rvas`; assume baddr == `image_base`.
 
-**Evidence discipline, applied inline (this is where the gate lives):**
-- Every capability and IOC is written in behavioral terms and **carries the function RVA (at its call
-  site) whose decompiled body proves it** — inline, e.g. *"encrypts victim files with ChaCha20
-  (member `0x…` in cluster `0xea390`)"* — never a bare claim, never citing only the cluster root.
-- **State an xrefer hypothesis only after you confirm it in a body.** One you could not verify is either
-  omitted or flagged inline as "unconfirmed" — never laundered as fact (its `xrefer_llm_guess` tag does
-  not become truth by being repeated).
-- **Report ALL cryptography** from the clusters' `artifacts.libs` (§2b): name every cipher and say which
-  is primary vs secondary from the bodies you read; a statically-linked crypto crate is a finding, not noise.
-- Pivot IOCs via `get_context_for_hash` / `get_ioc_assessment`; drop noisy ones.
+## Not in this file (do not look for them)
 
-**Coverage is internal discipline, not a section:** investigate every `investigation_queue` item before
-writing, and do not assert "benign"/complete while any `coverage.omitted.notable_rvas` RVA is unread —
-but this governs your *analysis*; it is not something you print.
-
-## 7. Identity, degraded mode, anti-patterns
-
-- **Cluster identity is `root_rva`.** A cluster `llm.relationships` string may name other clusters as
-  run-local `cluster.id.NNNN` tokens — never use those as stable keys, and do not invent an edge from
-  the prose; identity is always `root_rva`.
-- **Degraded (`meta.has_llm_layer:false`):** `verdict`, every cluster `llm` block, and `llm_lib`
-  collapse to null; the queue is scored purely on static signals. The static skeleton (clusters,
-  reachability, artifacts+call_site_rvas, danger_floor, coverage.omitted) is still a complete
-  Step-2/3 accelerator — proceed on structure and derive the verdict yourself.
-- Do NOT: report from the paste (any capability without a body quote); treat `noise`/omission as
-  "already triaged"; conclude "clean" with unread `notable_rvas`; use a run-local `cluster.id.NNNN`
-  token as a key; assume the base equals `image_base`.
-
-## Fields NOT in this format (do not look for them)
-
-To keep the single file pasteable, an anatomy JSON deliberately omits: decompiled code, cluster call
-graph `edges` (recover with `r2_callees` from the root), the full entity catalog (`entities[]` is
-referenced-only), staged rename/comment suggestions, crypto carve-target blobs, any binary-level prose
-report, and any binary-wide crate/dependency inventory. Per-function `artifacts.libs` IS present but
-filtered to cluster-local (signal) crates on the clusters this file shows — pervasive runtime crates are
-dropped, and crates used only by unclustered/below-cap code are not listed at all. When you need the
-omitted material or the unfiltered per-function `libs`, use the tiered `xrefer-agent-map` bundle (its
-`clusters/<root_rva>.json` carries edges + full artifacts, and `indices/` carries the reverse index,
-reachability, and full entity catalog).
+To stay pasteable, an anatomy JSON omits: decompiled code, cluster `edges` (recover with `r2_callees`),
+the full entity catalog (`entities[]` is referenced-only), rename/comment suggestions, any prose report,
+and any binary-wide dependency inventory. `artifacts.libs` is present but only for the shown top-N
+clusters (crates used only by unclustered/below-cap code are absent). For the omitted material use the
+tiered **`xrefer-agent-map`** bundle (its dossiers carry `edges` + full artifacts; `indices/` carries the
+reverse index, reachability, and full entity catalog).

--- a/plugins/xrefer/data/agent_skills/binary_anatomy.md
+++ b/plugins/xrefer/data/agent_skills/binary_anatomy.md
@@ -12,6 +12,13 @@ description: >-
 
 # binary_anatomy — consuming a single-file xrefer map
 
+## Prerequisite — activate your analysis skills first
+
+Before anything below, **confirm the `malware_analysis` and `format_binary` skills are active** in this
+session, and **activate them if they are not.** This skill only augments that workflow: `malware_analysis`
+owns the report format and the reverse-engineering doctrine, `format_binary` drives radare2, and this map
+pre-computes their triage and pivots. If those skills are unavailable, say so before proceeding.
+
 ## What this is (and is not)
 
 An `xrefer-binary-anatomy` JSON is a **plan**, not an analysis. It is xrefer's ranked answer to
@@ -155,10 +162,14 @@ evidence attached to each finding. Sections (`report_scaffold.sections`):
 3. **Capabilities** — the core, organized **by behavior** (execution, persistence, privilege-escalation,
    defense-evasion, credential-access, discovery, collection, cryptography, command-and-control,
    exfiltration, impact) — **not cluster by cluster.** Synthesize; do not echo the map's structure.
-4. **Host-based indicators** — files, registry keys, mutexes, services, processes, paths.
-5. **Network-based indicators** — C2 endpoints, URLs, protocols, ports.
-6. **MITRE ATT&CK** — technique-ids mapped to the behaviors you confirmed.
-7. **Conclusion** — overall assessment, likely family/attribution if evident, and your confidence.
+4. **Details** — a comprehensive technical walkthrough of the **entire** malware: its execution flow from
+   entry through every major component, covering the full binary (not only the headline behaviors), each
+   with the function RVAs and decompiled evidence behind it. This is the in-depth analysis; the
+   Capabilities section is its behavioral summary.
+5. **Host-based indicators** — files, registry keys, mutexes, services, processes, paths.
+6. **Network-based indicators** — C2 endpoints, URLs, protocols, ports.
+7. **MITRE ATT&CK** — technique-ids mapped to the behaviors you confirmed.
+8. **Conclusion** — overall assessment, likely family/attribution if evident, and your confidence.
 
 **Evidence discipline, applied inline (this is where the gate lives):**
 - Every capability and IOC is written in behavioral terms and **carries the function RVA (at its call

--- a/plugins/xrefer/data/agent_skills/binary_anatomy.md
+++ b/plugins/xrefer/data/agent_skills/binary_anatomy.md
@@ -104,8 +104,10 @@ but `investigation_queue[].why` and the static evidence are still only LEADS (wh
 ## 4. The loop — process EVERY queue item; score is order, not a skip license
 
 Walk `investigation_queue` top to bottom. **`static_score` sets the ORDER you work in; it does NOT
-license skipping.** Every queue item must end in a disposition (§6) — the queue is already xrefer's
-triaged shortlist, so an item you drop is signal you chose not to look at. For each item:
+license skipping.** Investigate every queue item to a resolution (confirmed / dismissed-with-evidence /
+blocked) before you write — this is internal coverage discipline, **not** a section you print (§6). The
+queue is already xrefer's triaged shortlist, so an item you drop is signal you chose not to look at. For
+each item:
 - Open `clusters[]` (match `root_rva == ref_rva`). `r2_decompile` the root **and every
   `must_read_rvas` function**, jumping to each function's `artifacts.*.call_site_rvas` (the exact
   instructions). `first_move` is the ready call.
@@ -140,26 +142,38 @@ and even that has a static safety net:
   mislabeled payload cannot hide. Never skip on the LLM library flag when a static `danger_floor`
   disagrees.
 
-## 6. OUTPUT CONTRACT (this is where the gate is enforced)
+## 6. THE DELIVERABLE — a malware analysis report (NOT a verification log)
 
-Follow `report_scaffold.output_contract`. Your report is checkable by re-reading it:
-1. **Disposition ledger FIRST — one row per `investigation_queue` item**, with a status: `confirmed`
-   (you read the root + all its `must_read_rvas`), `dismissed` (you read enough to justify it — state
-   the evidence, e.g. "root + members are statically-linked zlib"), or `blocked` (a tooling failure —
-   give the exact error and RVA). **No queue item may be silently absent.** A ledger with unexplained
-   gaps is an incomplete analysis.
-2. **Coverage header** computed from what you actually decompiled — e.g. *"12 confirmed / 2 dismissed /
-   1 blocked of 15 queued; unread danger-floor RVAs: none."*
-3. **Every capability sentence cites the specific member RVA (at its call site) whose body proves it,
-   with the decompiled excerpt** — a claim citing only the cluster root, or with no body quote, is
-   rejected.
-4. **Attribute every hypothesis:** "xrefer proposed X; I confirmed via r2_decompile @RVA" or "xrefer
-   proposed X; UNCONFIRMED" — never a bare `xrefer_llm_guess` value as fact.
-5. **The queue is not the whole binary.** No "benign"/completeness verdict while any
-   `coverage.omitted.notable_rvas` RVA is unread, and state plainly which demoted set you did not open
-   (`_readme.counts.clusters_llm_lib` / `clusters_static_lib`).
-6. Speak MITRE technique-ids for the TTP section; pivot IOCs via `get_context_for_hash` /
-   `get_ioc_assessment` and drop noisy ones. List unverified xrefer hypotheses explicitly.
+Follow `report_scaffold`. The output is a **standard malware analysis report in your `malware_analysis`
+format** — an intelligence product, not a table of what you verified. This map governs only *what you
+may claim and the evidence behind each claim*; it does **not** replace your report format. **Do not emit
+a disposition ledger or a coverage header** — verification is expressed *inside* the report as the
+evidence attached to each finding. Sections (`report_scaffold.sections`):
+1. **Executive summary** — what the sample is, its purpose, and severity, in a few sentences.
+2. **Identification** — sha256 / filename / size / format / arch, plus language / compiler / packer
+   (from `bind_check` + `image`).
+3. **Capabilities** — the core, organized **by behavior** (execution, persistence, privilege-escalation,
+   defense-evasion, credential-access, discovery, collection, cryptography, command-and-control,
+   exfiltration, impact) — **not cluster by cluster.** Synthesize; do not echo the map's structure.
+4. **Host-based indicators** — files, registry keys, mutexes, services, processes, paths.
+5. **Network-based indicators** — C2 endpoints, URLs, protocols, ports.
+6. **MITRE ATT&CK** — technique-ids mapped to the behaviors you confirmed.
+7. **Conclusion** — overall assessment, likely family/attribution if evident, and your confidence.
+
+**Evidence discipline, applied inline (this is where the gate lives):**
+- Every capability and IOC is written in behavioral terms and **carries the function RVA (at its call
+  site) whose decompiled body proves it** — inline, e.g. *"encrypts victim files with ChaCha20
+  (member `0x…` in cluster `0xea390`)"* — never a bare claim, never citing only the cluster root.
+- **State an xrefer hypothesis only after you confirm it in a body.** One you could not verify is either
+  omitted or flagged inline as "unconfirmed" — never laundered as fact (its `xrefer_llm_guess` tag does
+  not become truth by being repeated).
+- **Report ALL cryptography** from `dependency_bom` (§2b): name every cipher and say which is primary vs
+  secondary from the bodies you read; a statically-linked crypto crate is a finding, not noise.
+- Pivot IOCs via `get_context_for_hash` / `get_ioc_assessment`; drop noisy ones.
+
+**Coverage is internal discipline, not a section:** investigate every `investigation_queue` item before
+writing, and do not assert "benign"/complete while any `coverage.omitted.notable_rvas` RVA is unread —
+but this governs your *analysis*; it is not something you print.
 
 ## 7. Identity, degraded mode, anti-patterns
 

--- a/plugins/xrefer/data/agent_skills/xrefer_agent_map.md
+++ b/plugins/xrefer/data/agent_skills/xrefer_agent_map.md
@@ -1,5 +1,5 @@
 ---
-name: xrefer-agent-map
+name: xrefer_binary_anatomy
 description: >-
   Augments the format_binary (radare2) workflow. When an xrefer-agent-map bundle exists for the
   sample's sha256 (a map.json plus clusters/ and indices/ directories), it pre-computes your triage
@@ -9,7 +9,7 @@ description: >-
   body before you claim it.
 ---
 
-# xrefer-agent-map (a format_binary accelerator)
+# xrefer_binary_anatomy — the tiered xrefer-agent-map bundle (a format_binary accelerator)
 
 ## 0. Prerequisite
 

--- a/plugins/xrefer/data/agent_skills/xrefer_agent_map.md
+++ b/plugins/xrefer/data/agent_skills/xrefer_agent_map.md
@@ -30,8 +30,9 @@ Everything with `"provenance":"llm"` — cluster `label`, `function_prefix`, `mi
 verdict — is a **"listing": a hypothesis that satisfies your gate for nothing.** Your
 rule is unchanged: *no capability claim without a function body read; no confirmed function left
 unnamed; rename only on evidence.* The map's value is that it names **exactly which body** proves each
-hypothesis (`llm.verify_against.key_function_rvas` / `static.artifacts.*.call_site_rvas`). A report
-assembled from this map alone is the "listing is not reverse engineering" failure. Facts you may state
+hypothesis (each queue item's `must_read_rvas`, = `llm.verify_against.key_function_rvas`, at their
+`static.artifacts.*.call_site_rvas`). A report assembled from this map alone is the "listing is not
+reverse engineering" failure. Facts you may state
 directly are only the `"provenance":"static"` ones (RVAs, artifact names, xrefs, paths, capa,
 classification). See `provenance_legend` — and its `correction`: cluster `is_library` /
 `library_kind=="llm"` and per-function `origin` are LLM-DERIVED, not skip authority.
@@ -64,32 +65,39 @@ count is xrefer naming the dispatcher/hub you would otherwise hunt with `r2_call
 `indices/reachability.json["<rva>"]` gives `reachable` / `min_depth` / `shortest_path_rvas` / `n_paths`
 (a whole-program path from entry — not a single r2 call).
 
-**Step 4 (read the bodies) — THIS IS STILL YOUR JOB.** Walk `investigation_queue` top-down (it is
-score-ranked; each item's `first_move` is a ready r2 call and `detail_ref` names its Tier-1 file). For
-each item open `clusters/<root_rva>.json`:
-- `r2_decompile` the functions in `static.functions`, jumping to `static.artifacts.*.call_site_rvas`
-  (the exact instructions). **Skip a function only on the STATIC signals** `category=="func_lib"` /
-  `is_simple_api_thunk` (prioritize `origin:"user"`), never on the LLM library framing.
-- `static.edges` is the cluster's real call graph; `static.subcluster_refs` are trustworthy call
-  linkages into child clusters (`child_root_rva`).
-- Use `llm.verify_against.key_function_rvas` as the must-read set and `llm.mitre[].rationale` as the
-  claim to confirm. `llm.resolved_relationships` pre-resolves the cluster's prose `cluster.id.NNNN`
-  references to root RVAs; `llm.unresolved_run_ids` is an honest gap — do not invent that edge.
+**Step 4 (read the bodies) — THIS IS STILL YOUR JOB.** Walk `investigation_queue` top-down. **`score`
+sets the ORDER you work in, not a skip license — every queue item must be dispositioned** (Step 6);
+the queue is xrefer's triaged shortlist, so a dropped item is signal you chose not to look at. Each
+item's `must_read_rvas` is the bounded depth floor and `detail_ref` names its Tier-1 file. For each
+item open `clusters/<root_rva>.json`:
+- `r2_decompile` the root **and every `must_read_rvas` function** (= `llm.verify_against.key_function_
+  rvas` — the artifact-bearing members), jumping to `static.artifacts.*.call_site_rvas`. **The root
+  alone is not a disposition** — it is often just a dispatcher; the body that *makes* the call is
+  usually a member. Skip a function only on the STATIC `category=="func_lib"` / `is_simple_api_thunk`
+  (prioritize `origin:"user"`), never on the LLM library framing.
+- **Follow the behavior down the call chain.** `static.edges` is the cluster's real call graph and
+  `static.subcluster_refs` (`child_root_rva`) are trustworthy linkages into child clusters — step into
+  any child that consumes a parameter you care about.
+- `llm.mitre[].rationale` is the exact claim to confirm. `llm.resolved_relationships` pre-resolves the
+  cluster's prose `cluster.id.NNNN` references to root RVAs; `llm.unresolved_run_ids` is an honest gap
+  — do not invent that edge.
 
 **Step 5 (annotate) — on evidence.** After you confirm a function, name it what the body does with
 `r2_rename` and `r2_set_comments` (xrefer supplies `llm.function_prefix` as a *suggested* prefix only —
 a hypothesis, not a name to apply blind). Never apply a name you have not earned by reading the body.
 `r2_save_project` at the end of a block.
 
-**Step 6 (report)** — re-check the hard gate: every capability must trace to a body you read. Speak
-MITRE technique-ids aligned with the `mitre` kill-chain (`tactics_kill_chain_order`; each technique's
-`groundings[].cluster_root_rva` + `rationale` point at the cluster to confirm and the exact claim to
-test; `empty_tactics` = the LLM mapped no technique there, NOT proof of absence — a static
-`danger_floor` on a cluster overrides it). Build the report from **static counts + behaviors you
-confirmed**, citing
-addresses/functions — **not** from `indices/report.md` (LLM narrative, reference only; its header says
-so). Mark any xrefer hypothesis you could not confirm as unverified. Pivot IOCs through
-`get_context_for_hash` / `get_ioc_assessment` and drop noisy ones.
+**Step 6 (report)** — open with a **disposition ledger: one row per `investigation_queue` item**
+(`confirmed` = root + all `must_read_rvas` read / `dismissed` = read enough to justify, state the
+evidence / `blocked` = tooling failure, give the error+RVA). **No queue item may be silently absent.**
+Cite the specific **member** RVA (at its call site) whose body proves each capability — not the cluster
+root. State which demoted set you did not open (`stats.clusters_library`); the queue is not the whole
+binary. Speak MITRE technique-ids aligned with the kill-chain (`tactics_kill_chain_order`; each
+technique's `groundings[].cluster_root_rva` + `rationale` point at the cluster to confirm and the exact
+claim to test; `empty_tactics` = the LLM mapped no technique there, NOT proof of absence — a static
+`danger_floor` overrides it). Build the report from **static counts + behaviors you confirmed** —
+**not** from `indices/report.md` (LLM narrative, reference only). Mark any xrefer hypothesis you could
+not confirm as unverified. Pivot IOCs through `get_context_for_hash` / `get_ioc_assessment`.
 
 ## 5. Query cookbook (map field → next r2 call)
 
@@ -104,11 +112,13 @@ so). Mark any xrefer hypothesis you could not confirm as unverified. Pivot IOCs 
 
 ## 6. Noise, library demotion, completeness
 
-Do not conclude "clean" just because the queue is short — the safety net is **static**:
+Do not conclude "clean" just because the queue is short — the safety net is **static**. And note:
+**budget-saving means leaving demoted `clusters_index` rows unread — never an `investigation_queue`
+item** (every queue item must be dispositioned, Step 6).
 - `clusters_index` lists **every** cluster (signal + demoted). A row with `is_library:true` and
   `detail_ref:null` was excluded from the queue and Tier-1. `library_kind` distinguishes `"static"`
-  (deterministic FUNC_LIB — safe to skip) from `"llm"` (the `library_or_runtime` guess — a **budget
-  lever**: skip to save decompiler budget, but it is visible, not triaged).
+  (deterministic FUNC_LIB — safe to leave unread) from `"llm"` (the `library_or_runtime` guess — the
+  **budget lever**: leave unread to save budget, but it is visible, not triaged).
 - Any cluster with `danger_floor` set (process-injection / crypto / net-exfil / cred-access imports) or
   `promoted_from_noise:true` reaches the danger set statically and is force-kept in the queue even if
   the LLM called it library — so a mislabeled payload cannot hide. Never skip on the LLM library flag

--- a/plugins/xrefer/data/agent_skills/xrefer_agent_map.md
+++ b/plugins/xrefer/data/agent_skills/xrefer_agent_map.md
@@ -41,9 +41,9 @@ hypothesis (each queue item's `must_read_rvas`, = `llm.verify_against.key_functi
 `static.artifacts.*.call_site_rvas`). A report assembled from this map alone is the "listing is not
 reverse engineering" failure. Facts you may state
 directly are only the `"provenance":"static"` ones (RVAs, artifact names, xrefs, paths, capa,
-classification, and `dependency_bom` — the linked-crate parts list). See `provenance_legend` — and its
-`correction`: cluster `is_library` / `library_kind=="llm"` and per-function `origin` are LLM-DERIVED,
-not skip authority.
+classification, and each cluster's `static.artifacts.libs` — the linked crate refs). See
+`provenance_legend` — and its `correction`: cluster `is_library` / `library_kind=="llm"` and
+per-function `origin` are LLM-DERIVED, not skip authority.
 
 ## 3. Addressing, keys, and binding
 
@@ -67,18 +67,16 @@ kill-chain. Check `stats.backend_live` (see §7).
 fix for the Go / statically-linked **blind-regex failure**: xrefer already separated signal from the
 tens-of-thousands-of-strings noise. Spot-check with `r2_find_regex` only if the map looks thin.
 
-Read **`dependency_bom`** here first — it is the static crate/library parts list (from linked symbols),
-`signal` = cluster-local deps (crypto/compression/parsers/the sample's own modules, each with an
-`entity_idxs` and a `clusters_rva` → the cluster(s) that use it) and `pervasive` = language/runtime
-crates. **Crypto-claim discipline (where the "it only uses RC4" tunnel-vision fails):** report EVERY
-cipher/crypto crate in `signal`, not just the loudest — a ransomware build routinely links several
-(e.g. `chacha20` + `aes` + `ctr`/`cipher` for the file encryptor and `rsa` for key wrapping). Follow
-each crate's `clusters_rva` to its dossier, read the `must_read_rvas` bodies, and decide primary
-(encrypts victim data) vs secondary (key wrap / hashing / string obfuscation) from **behavior, not
-xref count** — a low-xref crate can be the primary bulk encryptor. A statically-linked crypto crate has
-no CryptoAPI import, so its cluster can rank mid-queue and its `danger_floor` can be null; that is not
-license to skip it. If `dependency_bom.signal` names a cipher, the binary HAS it — confirm *how* it is
-used, never *whether* it is present.
+Each cluster dossier lists the crates its functions link, on `static.artifacts.libs` (crate name +
+`call_site_rvas`) — static, symbol-table ground truth. **Crypto-claim discipline (where the "it only
+uses RC4" tunnel-vision fails):** as you read the queue's dossiers, report EVERY cipher/crypto crate you
+see, not just the loudest — a ransomware build routinely links several (e.g. `chacha20` + `aes` +
+`ctr`/`cipher` for the file encryptor and `rsa` for key wrapping). Read the body at each crate's
+`call_site_rvas` and decide primary (encrypts victim data) vs secondary (key wrap / hashing / string
+obfuscation) from **behavior, not frequency** — a rarely-referenced crate can be the primary bulk
+encryptor. A statically-linked crypto crate has no CryptoAPI import, so its cluster can rank mid-queue
+and its `danger_floor` can be null; that is not license to skip it. If a cipher crate is on a function,
+the binary HAS that cipher — confirm *how* it is used, never *whether* it is present.
 
 **Step 3 (pivot) — precomputed.** `indices/reverse_index.json["<entity_idx>"].function_rvas` is your
 `r2_xrefs_to` result (artifact → referencing functions). A large `indices/functions.json[fn].indirect`
@@ -128,8 +126,8 @@ shape. Verification lives *inline*:
   proves it — never the cluster root alone, never a bare claim.
 - State an xrefer hypothesis only after confirming it in a body; omit or mark "unconfirmed" the rest.
   Build from **behaviors you confirmed**, NOT from `indices/report.md` (LLM narrative, reference only).
-- **Report every crypto crate** from `dependency_bom` — name each cipher and say which is primary vs
-  secondary from the bodies.
+- **Report every crypto crate** from the clusters' `static.artifacts.libs` — name each cipher and say
+  which is primary vs secondary from the bodies.
 - Map MITRE technique-ids to confirmed behavior via the kill-chain (`tactics_kill_chain_order`; each
   technique's `groundings[].cluster_root_rva` + `rationale` is the cluster + claim to test; `empty_
   tactics` = unmapped, NOT proof of absence — a static `danger_floor` overrides it). Pivot IOCs through
@@ -148,8 +146,8 @@ shape. Verification lives *inline*:
 - *An artifact-bearing function with no path from entry?* → `orphans_index[]`; `r2_xrefs_to` it (the
   item's `next` field) to find the caller r2's static pass missed.
 - *Resolve an entity_idx to a name/group/xref count?* → `indices/entities.json`.
-- *What crypto / third-party crates does the binary link, and where?* → `map.json.dependency_bom.signal`
-  → each crate's `clusters_rva` → open that dossier and read its `must_read_rvas`.
+- *What crypto / third-party crates does a cluster link, and where?* → its
+  `clusters/<root_rva>.json` → `static.artifacts.libs` (crate name + `call_site_rvas`).
 
 ## 6. Noise, library demotion, completeness
 

--- a/plugins/xrefer/data/agent_skills/xrefer_agent_map.md
+++ b/plugins/xrefer/data/agent_skills/xrefer_agent_map.md
@@ -34,8 +34,9 @@ hypothesis (each queue item's `must_read_rvas`, = `llm.verify_against.key_functi
 `static.artifacts.*.call_site_rvas`). A report assembled from this map alone is the "listing is not
 reverse engineering" failure. Facts you may state
 directly are only the `"provenance":"static"` ones (RVAs, artifact names, xrefs, paths, capa,
-classification). See `provenance_legend` — and its `correction`: cluster `is_library` /
-`library_kind=="llm"` and per-function `origin` are LLM-DERIVED, not skip authority.
+classification, and `dependency_bom` — the linked-crate parts list). See `provenance_legend` — and its
+`correction`: cluster `is_library` / `library_kind=="llm"` and per-function `origin` are LLM-DERIVED,
+not skip authority.
 
 ## 3. Addressing, keys, and binding
 
@@ -58,6 +59,19 @@ kill-chain. Check `stats.backend_live` (see §7).
 `indices/entities.json` (curated, de-noised) instead of raw `r2_imports`/`r2_find_regex`. This is the
 fix for the Go / statically-linked **blind-regex failure**: xrefer already separated signal from the
 tens-of-thousands-of-strings noise. Spot-check with `r2_find_regex` only if the map looks thin.
+
+Read **`dependency_bom`** here first — it is the static crate/library parts list (from linked symbols),
+`signal` = cluster-local deps (crypto/compression/parsers/the sample's own modules, each with an
+`entity_idxs` and a `clusters_rva` → the cluster(s) that use it) and `pervasive` = language/runtime
+crates. **Crypto-claim discipline (where the "it only uses RC4" tunnel-vision fails):** report EVERY
+cipher/crypto crate in `signal`, not just the loudest — a ransomware build routinely links several
+(e.g. `chacha20` + `aes` + `ctr`/`cipher` for the file encryptor and `rsa` for key wrapping). Follow
+each crate's `clusters_rva` to its dossier, read the `must_read_rvas` bodies, and decide primary
+(encrypts victim data) vs secondary (key wrap / hashing / string obfuscation) from **behavior, not
+xref count** — a low-xref crate can be the primary bulk encryptor. A statically-linked crypto crate has
+no CryptoAPI import, so its cluster can rank mid-queue and its `danger_floor` can be null; that is not
+license to skip it. If `dependency_bom.signal` names a cipher, the binary HAS it — confirm *how* it is
+used, never *whether* it is present.
 
 **Step 3 (pivot) — precomputed.** `indices/reverse_index.json["<entity_idx>"].function_rvas` is your
 `r2_xrefs_to` result (artifact → referencing functions). A large `indices/functions.json[fn].indirect`
@@ -109,6 +123,8 @@ not confirm as unverified. Pivot IOCs through `get_context_for_hash` / `get_ioc_
 - *An artifact-bearing function with no path from entry?* → `orphans_index[]`; `r2_xrefs_to` it (the
   item's `next` field) to find the caller r2's static pass missed.
 - *Resolve an entity_idx to a name/group/xref count?* → `indices/entities.json`.
+- *What crypto / third-party crates does the binary link, and where?* → `map.json.dependency_bom.signal`
+  → each crate's `clusters_rva` → open that dossier and read its `must_read_rvas`.
 
 ## 6. Noise, library demotion, completeness
 

--- a/plugins/xrefer/data/agent_skills/xrefer_agent_map.md
+++ b/plugins/xrefer/data/agent_skills/xrefer_agent_map.md
@@ -27,7 +27,7 @@ is for binaries too large for the single-file `binary_anatomy`: everything is sp
 ## 2. THE HARD GATE STILL APPLIES (read this twice)
 
 Everything with `"provenance":"llm"` — cluster `label`, `function_prefix`, `mitre`, the `binary`
-verdict, each `one_line` — is a **"listing": a hypothesis that satisfies your gate for nothing.** Your
+verdict — is a **"listing": a hypothesis that satisfies your gate for nothing.** Your
 rule is unchanged: *no capability claim without a function body read; no confirmed function left
 unnamed; rename only on evidence.* The map's value is that it names **exactly which body** proves each
 hypothesis (`llm.verify_against.key_function_rvas` / `static.artifacts.*.call_site_rvas`). A report
@@ -43,8 +43,9 @@ classification). See `provenance_legend` — and its `correction`: cluster `is_l
   one known function first.
 - The bundle matches this sample **iff `image.sha256` == your `r2_init_project` sha256.** If it does
   not, do not apply these RVAs or any rename — it is a different sample.
-- **Cluster identity is `root_rva`** (also the address to `r2_decompile`). `run_ref` (`cluster.id.NNNN`)
-  is run-local — never use it as a stable key.
+- **Cluster identity is `root_rva`** (also the address to `r2_decompile`). The `cluster.id.NNNN` tokens
+  that appear inside a cluster's `llm.relationships` are run-local — never use them as keys; each is
+  pre-resolved to a `root_rva` for you in that cluster's `llm.resolved_relationships`.
 
 ## 4. Step-by-step: how the map folds into format_binary
 
@@ -82,8 +83,10 @@ a hypothesis, not a name to apply blind). Never apply a name you have not earned
 
 **Step 6 (report)** — re-check the hard gate: every capability must trace to a body you read. Speak
 MITRE technique-ids aligned with the `mitre` kill-chain (`tactics_kill_chain_order`; each technique's
-`groundings[].cluster_root_rva` + `cluster_root_rvas` point at the clusters to confirm; `empty_tactics`
-are unmapped). Build the report from **static counts + behaviors you confirmed**, citing
+`groundings[].cluster_root_rva` + `rationale` point at the cluster to confirm and the exact claim to
+test; `empty_tactics` = the LLM mapped no technique there, NOT proof of absence — a static
+`danger_floor` on a cluster overrides it). Build the report from **static counts + behaviors you
+confirmed**, citing
 addresses/functions — **not** from `indices/report.md` (LLM narrative, reference only; its header says
 so). Mark any xrefer hypothesis you could not confirm as unverified. Pivot IOCs through
 `get_context_for_hash` / `get_ioc_assessment` and drop noisy ones.
@@ -110,8 +113,8 @@ Do not conclude "clean" just because the queue is short — the safety net is **
   `promoted_from_noise:true` reaches the danger set statically and is force-kept in the queue even if
   the LLM called it library — so a mislabeled payload cannot hide. Never skip on the LLM library flag
   when a static `danger_floor` disagrees.
-- `stats.clusters_excluded_from_tier1` tells you how many clusters were demoted; a mislabeled cluster
-  is recoverable — re-examine one if you suspect it (`stats.note`).
+- `stats.clusters_library` tells you how many clusters were demoted (excluded from the queue and
+  Tier-1); a mislabeled cluster is recoverable — re-examine one if you suspect it.
 
 ## 7. Degraded mode and backend_live
 
@@ -130,15 +133,15 @@ Do not conclude "clean" just because the queue is short — the safety net is **
 ## 8. Anti-patterns
 
 Do NOT: report a capability you only saw in the map (no body read); apply a `function_prefix` before
-verifying; treat `label`/`mitre`/the `binary` verdict as fact; use absolute VAs or `run_ref` as stable
-keys; ask the map for a full callgraph or all-paths you can get from r2; or treat the map as exhaustive
-(library/orphan functions it demotes still exist — `stats.clusters_excluded_from_tier1` names what was
-skipped).
+verifying; treat `label`/`mitre`/the `binary` verdict as fact; use absolute VAs or run-local
+`cluster.id.NNNN` tokens as stable keys; ask the map for a full callgraph or all-paths you can get from
+r2; or treat the map as exhaustive (library/orphan functions it demotes still exist —
+`stats.clusters_library` names what was skipped).
 
 ## Fields NOT in this bundle (do not look for them)
 
 The shipped bundle deliberately omits fields that have no non-fabricated static source: per-cluster
 `recipe`/`pattern` strings, crypto `carve_targets`, staged `suggested_annotations`, and `all_paths_ref`
 sidecars. Confirm crypto by decompiling the routine and carving its data references yourself; recover
-extra paths with `r2_callees`. `indices/entities.json` carries no LLM `enrichment` — kind/group/name/
-xref_count are the static facts.
+extra paths with `r2_callees`. `indices/entities.json` carries only static facts — `idx`/`kind`/`name`/
+`xref_count` (plus a static capa `namespace` on capa entities); no LLM category/enrichment.

--- a/plugins/xrefer/data/agent_skills/xrefer_agent_map.md
+++ b/plugins/xrefer/data/agent_skills/xrefer_agent_map.md
@@ -76,7 +76,7 @@ comes from the bodies, not frequency; a linked crypto crate is evidence even wit
 | you need… | open |
 |---|---|
 | the ranked functions that matter | `map.json` → `investigation_queue` (+ each `detail_ref`) |
-| which functions reference an API/IOC (precomputed `r2_xrefs_to`) | `indices/reverse_index.json["<entity_idx>"].function_rvas` |
+| which functions reference an API/IOC (precomputed `r2_xrefs_to`) | `indices/reverse_index.json["<entity_idx>"].function_rvas` (scoped to in-scope artifacts; `r2_xrefs_to` for others) |
 | how entry reaches function Y | `indices/reachability.json["<Y>"]` → `shortest_path_rvas` / `n_paths` |
 | the dispatcher / config-gating hub | highest `indices/functions.json[fn].indirect` in scope |
 | an artifact-bearing function with no path from entry | `orphans_index[]` → `r2_xrefs_to` it (its `next`) |

--- a/plugins/xrefer/data/agent_skills/xrefer_agent_map.md
+++ b/plugins/xrefer/data/agent_skills/xrefer_agent_map.md
@@ -11,6 +11,13 @@ description: >-
 
 # xrefer-agent-map (a format_binary accelerator)
 
+## 0. Prerequisite — activate your analysis skills first
+
+Before anything below, **confirm the `malware_analysis` and `format_binary` skills are active** in this
+session, and **activate them if they are not.** This skill only augments that workflow: `malware_analysis`
+owns the report format and reverse-engineering doctrine, `format_binary` drives radare2, and this map
+pre-computes their triage and pivots. If those skills are unavailable, say so before proceeding.
+
 ## 1. What it is and where it fits
 
 This is **not** a replacement for `format_binary` — it plugs into it. xrefer already ran whole-program
@@ -105,14 +112,18 @@ a hypothesis, not a name to apply blind). Never apply a name you have not earned
 **Step 6 (report) — a malware analysis report, NOT a verification log.** Produce a **standard malware
 analysis report in your `malware_analysis` format**, self-contained in these sections: **executive
 summary** (what the sample is, purpose, severity) → **identification** (sha256/filename/size/format/arch
-+ language/packer, from `image`) → **capabilities** → **host-based indicators** (files/registry/mutexes/
-services/processes) → **network-based indicators** (C2/URLs/protocols/ports) → **MITRE ATT&CK** →
-**conclusion** (assessment + likely family/attribution + confidence). **Do NOT open with a disposition
-ledger or a coverage header** — the map governs what you may claim, not your report shape. Verification
-lives *inline*:
++ language/packer, from `image`) → **capabilities** → **details** → **host-based indicators**
+(files/registry/mutexes/services/processes) → **network-based indicators** (C2/URLs/protocols/ports) →
+**MITRE ATT&CK** → **conclusion** (assessment + likely family/attribution + confidence). **Do NOT open
+with a disposition ledger or a coverage header** — the map governs what you may claim, not your report
+shape. Verification lives *inline*:
 - Organize **capabilities by behavior** (execution, persistence, privilege-escalation, defense-evasion,
   credential-access, discovery, collection, cryptography, C2, exfiltration, impact) — **not cluster by
   cluster.** Synthesize; do not echo the map.
+- The **details** section is a comprehensive technical walkthrough of the **entire** malware — its
+  execution flow from entry through every major component, covering the full binary (not only the
+  headline behaviors), each with its function RVAs and decompiled evidence. Capabilities is the summary;
+  details is the in-depth analysis.
 - Every capability and IOC carries, inline, the **member** RVA (at its call site) whose decompiled body
   proves it — never the cluster root alone, never a bare claim.
 - State an xrefer hypothesis only after confirming it in a body; omit or mark "unconfirmed" the rest.

--- a/plugins/xrefer/data/agent_skills/xrefer_agent_map.md
+++ b/plugins/xrefer/data/agent_skills/xrefer_agent_map.md
@@ -2,195 +2,134 @@
 name: xrefer-agent-map
 description: >-
   Augments the format_binary (radare2) workflow. When an xrefer-agent-map bundle exists for the
-  sample's sha256 (a map.json plus clusters/ and indices/ directories), it pre-computes your Step-2
-  triage sweep and Step-3 indicator->code pivots and drops you into Step 4 with a ranked list of the
-  functions that matter and the exact addresses to r2_decompile. Load map.json at r2_init_project
-  time. It is reconnaissance, not analysis: it never satisfies your hard gate — you still read every
+  sample's sha256 (a map.json plus clusters/ and indices/ directories), it pre-computes your triage
+  sweep and indicator->code pivots and drops you into the read-the-bodies step with a ranked queue of
+  the functions that matter and the exact addresses to decompile. Load map.json at r2_init_project
+  time. It is reconnaissance, not analysis: you still read (decompile, or disassemble on failure) every
   body before you claim it.
 ---
 
 # xrefer-agent-map (a format_binary accelerator)
 
-## 0. Prerequisite — activate your analysis skills first
+## 0. Prerequisite
 
-Before anything below, **confirm the `malware_analysis` and `format_binary` skills are active** in this
-session, and **activate them if they are not.** This skill only augments that workflow: `malware_analysis`
-owns the report format and reverse-engineering doctrine, `format_binary` drives radare2, and this map
-pre-computes their triage and pivots. If those skills are unavailable, say so before proceeding.
+Confirm the **`malware_analysis`** and **`format_binary`** skills are active in this session, and
+**activate them if they are not.** This skill only augments them: `malware_analysis` owns the report
+format and RE doctrine, `format_binary` drives radare2, this map pre-computes their triage. Say so if
+they are unavailable.
 
-## 1. What it is and where it fits
+## 1. What it is
 
-This is **not** a replacement for `format_binary` — it plugs into it. xrefer already ran whole-program
-analysis on this sample and produced a **curated, de-noised, semantically-grouped** version of the
-triage and pivots you would do by hand: clustered imports/strings/capa, a precomputed `r2_xrefs_to`,
-whole-program reachability, and an LLM interpretation layer. Its job is to spend your r2 budget where
-it matters — it tells you **where to point `r2_decompile`**, not what the code does. The tiered layout
-is for binaries too large for the single-file `binary_anatomy`: everything is split across files and
-**lazy-loaded** — fetch only what a given pivot needs.
+xrefer already ran whole-program analysis and produced a **curated, de-noised, semantically-grouped**
+version of the triage and pivots you would do by hand: clustered imports/strings/capa, a precomputed
+`r2_xrefs_to`, whole-program reachability, and an LLM interpretation layer. It tells you **where to point
+`r2_decompile`**, not what the code does. It is **lazy-loaded** — load `map.json` at `r2_init_project`
+time, then fetch other files only when a pivot needs them. **`manifest` is the file index**: it lists
+every `clusters/*.json` and index, and `manifest.tier2[].load_when` says when to open each — consult it
+instead of loading everything.
 
-**Load `map.json` at `r2_init_project` time** if a bundle exists for this sha256. Then run the normal
-6 steps — `schema.workflow_binding.section_to_step` maps each section to the step it accelerates.
+## 2. Bind + provenance (fail-closed)
 
-## 2. THE HARD GATE STILL APPLIES (read this twice)
+- **Bind:** `r2_addr = r2_baddr + rva` (see `image.recipe`). **If `image.sha256` != your
+  `r2_init_project` sha256, REFUSE** — different sample; do not apply these RVAs or any rename.
+- **Provenance (`provenance_legend`):** state as fact only `"provenance":"static"` values (RVAs, artifact
+  names, xrefs, paths, capa, classification, each cluster's `static.artifacts.libs`). Everything
+  `"provenance":"llm"` — cluster `label`/`function_prefix`/`mitre`, the `binary` verdict — is a
+  **hypothesis** that satisfies your gate for nothing. Its `correction`: cluster `is_library` /
+  `library_kind=="llm"` and per-function `origin` are LLM-derived, **not** skip authority; the static
+  skip signal is `category=="func_lib"`.
+- **Cluster identity is `root_rva`** (also the address to decompile). The `cluster.id.NNNN` tokens in a
+  cluster's `llm.relationships` are run-local — never keys; each is pre-resolved in
+  `llm.resolved_relationships`.
 
-Everything with `"provenance":"llm"` — cluster `label`, `function_prefix`, `mitre`, the `binary`
-verdict — is a **"listing": a hypothesis that satisfies your gate for nothing.** Your
-rule is unchanged: *no capability claim without a function body read; no confirmed function left
-unnamed; rename only on evidence.* The map's value is that it names **exactly which body** proves each
-hypothesis (each queue item's `must_read_rvas`, = `llm.verify_against.key_function_rvas`, at their
-`static.artifacts.*.call_site_rvas`). A report assembled from this map alone is the "listing is not
-reverse engineering" failure. Facts you may state
-directly are only the `"provenance":"static"` ones (RVAs, artifact names, xrefs, paths, capa,
-classification, and each cluster's `static.artifacts.libs` — the linked crate refs). See
-`provenance_legend` — and its `correction`: cluster `is_library` / `library_kind=="llm"` and
-per-function `origin` are LLM-DERIVED, not skip authority.
+## 3. THE CORE LOOP — work the queue, decompile recursively, disassemble on failure
 
-## 3. Addressing, keys, and binding
+`investigation_queue` is xrefer's ranked shortlist. **`score` is the ORDER you work in, not a license to
+skip** — take every item to a resolution (confirmed / dismissed-with-evidence / blocked) before you
+write. For each item (its `detail_ref` names the Tier-1 file, open `clusters/<root_rva>.json`):
 
-- `r2_addr = r2_baddr + rva` (see `image.recipe`). For a normally-mapped image `r2_baddr ==
-  image.image_base_va`; if your session is rebased (PIE/ASLR/-B) substitute your own baddr and confirm
-  one known function first.
-- The bundle matches this sample **iff `image.sha256` == your `r2_init_project` sha256.** If it does
-  not, do not apply these RVAs or any rename — it is a different sample.
-- **Cluster identity is `root_rva`** (also the address to `r2_decompile`). The `cluster.id.NNNN` tokens
-  that appear inside a cluster's `llm.relationships` are run-local — never use them as keys; each is
-  pre-resolved to a `root_rva` for you in that cluster's `llm.resolved_relationships`.
+1. **Decompile the root AND every `must_read_rvas`** (= `llm.verify_against.key_function_rvas`, the
+   artifact-bearing members), jumping to `static.artifacts.*.call_site_rvas`. **The root alone is never a
+   disposition** — it is usually a dispatcher.
+2. **Recurse down the call chain.** `static.edges` is the cluster's real call graph and
+   `static.subcluster_refs[].child_root_rva` are trustworthy links into child clusters — **decompile the
+   callees too**, stepping into any child that consumes data you care about, until a leaf body proves the
+   behavior. `r2_callees` for anything beyond the dossier's edges.
+3. **On decompile failure, disassemble.** When `r2_decompile` errors or returns garbage (r2ghidra can
+   choke on obfuscated/odd code), fall back to **`r2_disasm`** for that function; use `r2_get_bytes` /
+   `r2_get_string` for data. **Never leave a must-read uncovered because the decompiler failed** — mark it
+   blocked only if both fail.
+4. **Skip a function only on the STATIC** `category=="func_lib"` / `is_simple_api_thunk` (prioritize
+   `origin:"user"`), never on LLM library framing.
 
-## 4. Step-by-step: how the map folds into format_binary
+**The gate:** no capability claim without a body you read; no confirmed function left unnamed; rename only
+on evidence. `llm.mitre[].rationale` is the exact claim to confirm; `llm.unresolved_run_ids` is an honest
+gap — do not invent that edge.
 
-**Step 1 (init)** — after `r2_init_project`, load `map.json`. Read `entry_anchor` (application vs
-runtime roots; `read_first_rva`), `stats`, the `binary` verdict (a hypothesis), and the `mitre`
-kill-chain. Check `stats.backend_live` (see §7).
+**Crypto note (anti-tunnel-vision):** each dossier's `static.artifacts.libs` lists the crates its
+functions link. Report **every** cipher crate you see, not just the loudest — a ransomware build routinely
+links several (`chacha20` + `aes` + `ctr` for the encryptor, `rsa` for key wrapping). Primary vs secondary
+comes from the bodies, not frequency; a linked crypto crate is evidence even with a null `danger_floor`.
 
-**Step 2 (triage) — mostly done for you.** Use `investigation_queue` instead of a blind sweep, and
-`indices/entities.json` (curated, de-noised) instead of raw `r2_imports`/`r2_find_regex`. This is the
-fix for the Go / statically-linked **blind-regex failure**: xrefer already separated signal from the
-tens-of-thousands-of-strings noise. Spot-check with `r2_find_regex` only if the map looks thin.
+## 4. Cookbook — when you need X, open Y (lazy-load only these)
 
-Each cluster dossier lists the crates its functions link, on `static.artifacts.libs` (crate name +
-`call_site_rvas`) — static, symbol-table ground truth. **Crypto-claim discipline (where the "it only
-uses RC4" tunnel-vision fails):** as you read the queue's dossiers, report EVERY cipher/crypto crate you
-see, not just the loudest — a ransomware build routinely links several (e.g. `chacha20` + `aes` +
-`ctr`/`cipher` for the file encryptor and `rsa` for key wrapping). Read the body at each crate's
-`call_site_rvas` and decide primary (encrypts victim data) vs secondary (key wrap / hashing / string
-obfuscation) from **behavior, not frequency** — a rarely-referenced crate can be the primary bulk
-encryptor. A statically-linked crypto crate has no CryptoAPI import, so its cluster can rank mid-queue
-and its `danger_floor` can be null; that is not license to skip it. If a cipher crate is on a function,
-the binary HAS that cipher — confirm *how* it is used, never *whether* it is present.
+| you need… | open |
+|---|---|
+| the ranked functions that matter | `map.json` → `investigation_queue` (+ each `detail_ref`) |
+| which functions reference an API/IOC (precomputed `r2_xrefs_to`) | `indices/reverse_index.json["<entity_idx>"].function_rvas` |
+| how entry reaches function Y | `indices/reachability.json["<Y>"]` → `shortest_path_rvas` / `n_paths` |
+| the dispatcher / config-gating hub | highest `indices/functions.json[fn].indirect` in scope |
+| an artifact-bearing function with no path from entry | `orphans_index[]` → `r2_xrefs_to` it (its `next`) |
+| an `entity_idx` → name / kind / xref_count | `indices/entities.json` |
+| the crates a cluster links, and where | `clusters/<root_rva>.json` → `static.artifacts.libs` |
+| the MITRE kill-chain + what grounds each technique | `map.json.mitre` → `tactics_kill_chain_order`, `groundings[].cluster_root_rva` |
+| what was DEMOTED (library/orphan), i.e. what you skipped | `clusters_index` (`is_library` / `detail_ref:null`) + `stats.clusters_library` |
 
-**Step 3 (pivot) — precomputed.** `indices/reverse_index.json["<entity_idx>"].function_rvas` is your
-`r2_xrefs_to` result (artifact → referencing functions). A large `indices/functions.json[fn].indirect`
-count is xrefer naming the dispatcher/hub you would otherwise hunt with `r2_callees`.
-`indices/reachability.json["<rva>"]` gives `reachable` / `min_depth` / `shortest_path_rvas` / `n_paths`
-(a whole-program path from entry — not a single r2 call).
+`indices/report.md` is xrefer's LLM narrative — **reference only, never your report's spine.**
 
-**Step 4 (read the bodies) — THIS IS STILL YOUR JOB.** Walk `investigation_queue` top-down. **`score`
-sets the ORDER you work in, not a skip license — investigate every queue item to a resolution
-(confirmed / dismissed-with-evidence / blocked) before you write.** This is internal coverage, not a
-report section (Step 6); the queue is xrefer's triaged shortlist, so a dropped item is signal you chose
-not to look at. Each item's `must_read_rvas` is the bounded depth floor and `detail_ref` names its
-Tier-1 file. For each item open `clusters/<root_rva>.json`:
-- `r2_decompile` the root **and every `must_read_rvas` function** (= `llm.verify_against.key_function_
-  rvas` — the artifact-bearing members), jumping to `static.artifacts.*.call_site_rvas`. **The root
-  alone is not a disposition** — it is often just a dispatcher; the body that *makes* the call is
-  usually a member. Skip a function only on the STATIC `category=="func_lib"` / `is_simple_api_thunk`
-  (prioritize `origin:"user"`), never on the LLM library framing.
-- **Follow the behavior down the call chain.** `static.edges` is the cluster's real call graph and
-  `static.subcluster_refs` (`child_root_rva`) are trustworthy linkages into child clusters — step into
-  any child that consumes a parameter you care about.
-- `llm.mitre[].rationale` is the exact claim to confirm. `llm.resolved_relationships` pre-resolves the
-  cluster's prose `cluster.id.NNNN` references to root RVAs; `llm.unresolved_run_ids` is an honest gap
-  — do not invent that edge.
+## 5. What you may skip, and completeness
 
-**Step 5 (annotate) — on evidence.** After you confirm a function, name it what the body does with
-`r2_rename` and `r2_set_comments` (xrefer supplies `llm.function_prefix` as a *suggested* prefix only —
-a hypothesis, not a name to apply blind). Never apply a name you have not earned by reading the body.
-`r2_save_project` at the end of a block.
+- **The demoted set is the only budget lever.** `clusters_index` lists **every** cluster; a row with
+  `is_library:true` + `detail_ref:null` was excluded from the queue and Tier-1. `library_kind=="static"`
+  (deterministic FUNC_LIB) is safe to leave unread; `library_kind=="llm"` you MAY leave unread to save
+  budget, but it is visible, not triaged. **Never** skip an `investigation_queue` item.
+- Any cluster with `danger_floor` set or `promoted_from_noise:true` reaches the danger set statically and
+  is force-kept in the queue even if the LLM called it library — a mislabeled payload cannot hide. Do not
+  conclude "clean" from a short queue; the safety net is static, and `stats.clusters_library` is what you
+  chose not to open.
 
-**Step 6 (report) — a malware analysis report, NOT a verification log.** Produce a **standard malware
-analysis report in your `malware_analysis` format**, self-contained in these sections: **executive
-summary** (what the sample is, purpose, severity) → **identification** (sha256/filename/size/format/arch
-+ language/packer, from `image`) → **capabilities** → **details** → **host-based indicators**
-(files/registry/mutexes/services/processes) → **network-based indicators** (C2/URLs/protocols/ports) →
-**MITRE ATT&CK** → **conclusion** (assessment + likely family/attribution + confidence). **Do NOT open
-with a disposition ledger or a coverage header** — the map governs what you may claim, not your report
-shape. Verification lives *inline*:
-- Organize **capabilities by behavior** (execution, persistence, privilege-escalation, defense-evasion,
-  credential-access, discovery, collection, cryptography, C2, exfiltration, impact) — **not cluster by
-  cluster.** Synthesize; do not echo the map.
-- The **details** section is a comprehensive technical walkthrough of the **entire** malware — its
-  execution flow from entry through every major component, covering the full binary (not only the
-  headline behaviors), each with its function RVAs and decompiled evidence. Capabilities is the summary;
-  details is the in-depth analysis.
-- Every capability and IOC carries, inline, the **member** RVA (at its call site) whose decompiled body
-  proves it — never the cluster root alone, never a bare claim.
-- State an xrefer hypothesis only after confirming it in a body; omit or mark "unconfirmed" the rest.
-  Build from **behaviors you confirmed**, NOT from `indices/report.md` (LLM narrative, reference only).
-- **Report every crypto crate** from the clusters' `static.artifacts.libs` — name each cipher and say
-  which is primary vs secondary from the bodies.
-- Map MITRE technique-ids to confirmed behavior via the kill-chain (`tactics_kill_chain_order`; each
-  technique's `groundings[].cluster_root_rva` + `rationale` is the cluster + claim to test; `empty_
-  tactics` = unmapped, NOT proof of absence — a static `danger_floor` overrides it). Pivot IOCs through
+## 6. The deliverable — a malware analysis report (NOT a verification log)
+
+Produce a **standard malware analysis report in your `malware_analysis` format**, self-contained in these
+sections: **executive summary → identification (`image`) → capabilities (organized by behavior, not
+cluster) → details (a full technical walkthrough of the entire malware, component by component) →
+host-based indicators → network-based indicators → MITRE ATT&CK → conclusion.** **Do NOT open with a
+disposition ledger or coverage header** — the map governs what you may claim, not your report shape;
+verification lives *inline*.
+- Every capability and IOC carries, inline, the **member** RVA (at its call site) whose body proves it.
+- State an xrefer hypothesis only after confirming it in a body; build from **behaviors you confirmed**,
+  NOT from `indices/report.md`.
+- Report every crypto crate from the clusters' `static.artifacts.libs`.
+- Map MITRE technique-ids to confirmed behavior via `tactics_kill_chain_order` (`empty_tactics` =
+  unmapped, NOT proof of absence — a static `danger_floor` overrides it). Pivot IOCs via
   `get_context_for_hash` / `get_ioc_assessment`.
-- **Coverage is internal discipline, not a section:** don't claim complete/benign while a `danger_floor`
-  cluster is unread (`stats.clusters_library` is what you demoted) — but that governs your analysis, it
-  is not printed.
+- **Coverage is internal discipline, not a section:** cover every queue item and don't claim
+  complete/benign while a `danger_floor` cluster is unread — but that governs your analysis, it is not printed.
 
-## 5. Query cookbook (map field → next r2 call)
+## 7. Degraded mode & backend_live
 
-- *Which functions reference this API/IOC?* → `reverse_index["<entity_idx>"].function_rvas` →
-  `r2_decompile` each.
-- *How does entry reach function Y?* → `reachability["<Y>"].shortest_path_rvas` (with `n_paths`).
-- *Where is the dispatcher / config-gating hub?* → highest `functions.json[fn].indirect` in scope.
-- *What does function W touch, and exactly where?* → its cluster's `static.artifacts.*.call_site_rvas`.
-- *An artifact-bearing function with no path from entry?* → `orphans_index[]`; `r2_xrefs_to` it (the
-  item's `next` field) to find the caller r2's static pass missed.
-- *Resolve an entity_idx to a name/group/xref count?* → `indices/entities.json`.
-- *What crypto / third-party crates does a cluster link, and where?* → its
-  `clusters/<root_rva>.json` → `static.artifacts.libs` (crate name + `call_site_rvas`).
-
-## 6. Noise, library demotion, completeness
-
-Do not conclude "clean" just because the queue is short — the safety net is **static**. And note:
-**budget-saving means leaving demoted `clusters_index` rows unread — never an `investigation_queue`
-item** (investigate every queue item; Step 4).
-- `clusters_index` lists **every** cluster (signal + demoted). A row with `is_library:true` and
-  `detail_ref:null` was excluded from the queue and Tier-1. `library_kind` distinguishes `"static"`
-  (deterministic FUNC_LIB — safe to leave unread) from `"llm"` (the `library_or_runtime` guess — the
-  **budget lever**: leave unread to save budget, but it is visible, not triaged).
-- Any cluster with `danger_floor` set (process-injection / crypto / net-exfil / cred-access imports) or
-  `promoted_from_noise:true` reaches the danger set statically and is force-kept in the queue even if
-  the LLM called it library — so a mislabeled payload cannot hide. Never skip on the LLM library flag
-  when a static `danger_floor` disagrees.
-- `stats.clusters_library` tells you how many clusters were demoted (excluded from the queue and
-  Tier-1); a mislabeled cluster is recoverable — re-examine one if you suspect it.
-
-## 7. Degraded mode and backend_live
-
-- **`schema.has_llm_layer:false`** → `binary`, `mitre`, every cluster `llm` block, and the labels in
-  `clusters_index`/`investigation_queue` are null, and the queue is scored on static signals only.
-  The static skeleton (clusters, edges, artifacts+call sites, reachability, reverse index, orphans,
-  danger_floor) is still a complete Step-2/3 accelerator — proceed on structure, derive the verdict
-  yourself. No `"provenance":"llm"` value exists in the bundle, so nothing needs de-hypothesizing —
-  you still read the bodies as always.
-- **`stats.backend_live:false`** → this bundle was exported headless from a cached analysis where the
-  live disassembler backend was unavailable, so per-function `has_default_name` is `null` and
-  `category`/`origin` come from persisted cluster membership (static `func_lib` detection needs the
-  live backend, i.e. the in-tool export). Trust `category`/`origin` as membership-derived; treat
+- **`schema.has_llm_layer:false`** → `binary`, `mitre`, every `llm` block and `clusters_index`/queue
+  labels are null; the queue is scored on static signals only. The static skeleton (clusters, edges,
+  artifacts + call sites, reachability, reverse index, orphans, danger_floor) is still a complete
+  accelerator — work the queue and derive the verdict yourself.
+- **`stats.backend_live:false`** → exported headless from cache; `has_default_name` is null and
+  `category`/`origin` come from persisted membership. Trust them as membership-derived; treat
   `has_default_name:null` as "unknown," not "false."
 
-## 8. Anti-patterns
+## Not in this bundle (do not look for them)
 
-Do NOT: report a capability you only saw in the map (no body read); apply a `function_prefix` before
-verifying; treat `label`/`mitre`/the `binary` verdict as fact; use absolute VAs or run-local
-`cluster.id.NNNN` tokens as stable keys; ask the map for a full callgraph or all-paths you can get from
-r2; or treat the map as exhaustive (library/orphan functions it demotes still exist —
-`stats.clusters_library` names what was skipped).
-
-## Fields NOT in this bundle (do not look for them)
-
-The shipped bundle deliberately omits fields that have no non-fabricated static source: per-cluster
-`recipe`/`pattern` strings, crypto `carve_targets`, staged `suggested_annotations`, and `all_paths_ref`
-sidecars. Confirm crypto by decompiling the routine and carving its data references yourself; recover
-extra paths with `r2_callees`. `indices/entities.json` carries only static facts — `idx`/`kind`/`name`/
-`xref_count` (plus a static capa `namespace` on capa entities); no LLM category/enrichment.
+The bundle omits fields with no non-fabricated static source: per-cluster `recipe`/`pattern`, crypto
+`carve_targets`, staged `suggested_annotations`, `all_paths_ref` sidecars. Confirm crypto by decompiling
+the routine and carving its data refs; recover extra paths with `r2_callees`. `indices/entities.json`
+carries only static facts (no LLM category/enrichment). Do not ask the map for a full callgraph or
+all-paths you can get from r2, and do not treat it as exhaustive — the demoted set still exists.

--- a/plugins/xrefer/data/agent_skills/xrefer_agent_map.md
+++ b/plugins/xrefer/data/agent_skills/xrefer_agent_map.md
@@ -80,10 +80,11 @@ count is xrefer naming the dispatcher/hub you would otherwise hunt with `r2_call
 (a whole-program path from entry — not a single r2 call).
 
 **Step 4 (read the bodies) — THIS IS STILL YOUR JOB.** Walk `investigation_queue` top-down. **`score`
-sets the ORDER you work in, not a skip license — every queue item must be dispositioned** (Step 6);
-the queue is xrefer's triaged shortlist, so a dropped item is signal you chose not to look at. Each
-item's `must_read_rvas` is the bounded depth floor and `detail_ref` names its Tier-1 file. For each
-item open `clusters/<root_rva>.json`:
+sets the ORDER you work in, not a skip license — investigate every queue item to a resolution
+(confirmed / dismissed-with-evidence / blocked) before you write.** This is internal coverage, not a
+report section (Step 6); the queue is xrefer's triaged shortlist, so a dropped item is signal you chose
+not to look at. Each item's `must_read_rvas` is the bounded depth floor and `detail_ref` names its
+Tier-1 file. For each item open `clusters/<root_rva>.json`:
 - `r2_decompile` the root **and every `must_read_rvas` function** (= `llm.verify_against.key_function_
   rvas` — the artifact-bearing members), jumping to `static.artifacts.*.call_site_rvas`. **The root
   alone is not a disposition** — it is often just a dispatcher; the body that *makes* the call is
@@ -101,17 +102,30 @@ item open `clusters/<root_rva>.json`:
 a hypothesis, not a name to apply blind). Never apply a name you have not earned by reading the body.
 `r2_save_project` at the end of a block.
 
-**Step 6 (report)** — open with a **disposition ledger: one row per `investigation_queue` item**
-(`confirmed` = root + all `must_read_rvas` read / `dismissed` = read enough to justify, state the
-evidence / `blocked` = tooling failure, give the error+RVA). **No queue item may be silently absent.**
-Cite the specific **member** RVA (at its call site) whose body proves each capability — not the cluster
-root. State which demoted set you did not open (`stats.clusters_library`); the queue is not the whole
-binary. Speak MITRE technique-ids aligned with the kill-chain (`tactics_kill_chain_order`; each
-technique's `groundings[].cluster_root_rva` + `rationale` point at the cluster to confirm and the exact
-claim to test; `empty_tactics` = the LLM mapped no technique there, NOT proof of absence — a static
-`danger_floor` overrides it). Build the report from **static counts + behaviors you confirmed** —
-**not** from `indices/report.md` (LLM narrative, reference only). Mark any xrefer hypothesis you could
-not confirm as unverified. Pivot IOCs through `get_context_for_hash` / `get_ioc_assessment`.
+**Step 6 (report) — a malware analysis report, NOT a verification log.** Produce a **standard malware
+analysis report in your `malware_analysis` format**, self-contained in these sections: **executive
+summary** (what the sample is, purpose, severity) → **identification** (sha256/filename/size/format/arch
++ language/packer, from `image`) → **capabilities** → **host-based indicators** (files/registry/mutexes/
+services/processes) → **network-based indicators** (C2/URLs/protocols/ports) → **MITRE ATT&CK** →
+**conclusion** (assessment + likely family/attribution + confidence). **Do NOT open with a disposition
+ledger or a coverage header** — the map governs what you may claim, not your report shape. Verification
+lives *inline*:
+- Organize **capabilities by behavior** (execution, persistence, privilege-escalation, defense-evasion,
+  credential-access, discovery, collection, cryptography, C2, exfiltration, impact) — **not cluster by
+  cluster.** Synthesize; do not echo the map.
+- Every capability and IOC carries, inline, the **member** RVA (at its call site) whose decompiled body
+  proves it — never the cluster root alone, never a bare claim.
+- State an xrefer hypothesis only after confirming it in a body; omit or mark "unconfirmed" the rest.
+  Build from **behaviors you confirmed**, NOT from `indices/report.md` (LLM narrative, reference only).
+- **Report every crypto crate** from `dependency_bom` — name each cipher and say which is primary vs
+  secondary from the bodies.
+- Map MITRE technique-ids to confirmed behavior via the kill-chain (`tactics_kill_chain_order`; each
+  technique's `groundings[].cluster_root_rva` + `rationale` is the cluster + claim to test; `empty_
+  tactics` = unmapped, NOT proof of absence — a static `danger_floor` overrides it). Pivot IOCs through
+  `get_context_for_hash` / `get_ioc_assessment`.
+- **Coverage is internal discipline, not a section:** don't claim complete/benign while a `danger_floor`
+  cluster is unread (`stats.clusters_library` is what you demoted) — but that governs your analysis, it
+  is not printed.
 
 ## 5. Query cookbook (map field → next r2 call)
 
@@ -130,7 +144,7 @@ not confirm as unverified. Pivot IOCs through `get_context_for_hash` / `get_ioc_
 
 Do not conclude "clean" just because the queue is short — the safety net is **static**. And note:
 **budget-saving means leaving demoted `clusters_index` rows unread — never an `investigation_queue`
-item** (every queue item must be dispositioned, Step 6).
+item** (investigate every queue item; Step 4).
 - `clusters_index` lists **every** cluster (signal + demoted). A row with `is_library:true` and
   `detail_ref:null` was excluded from the queue and Tier-1. `library_kind` distinguishes `"static"`
   (deterministic FUNC_LIB — safe to leave unread) from `"llm"` (the `library_or_runtime` guess — the

--- a/plugins/xrefer/data/agent_skills/xrefer_agent_map.md
+++ b/plugins/xrefer/data/agent_skills/xrefer_agent_map.md
@@ -1,0 +1,144 @@
+---
+name: xrefer-agent-map
+description: >-
+  Augments the format_binary (radare2) workflow. When an xrefer-agent-map bundle exists for the
+  sample's sha256 (a map.json plus clusters/ and indices/ directories), it pre-computes your Step-2
+  triage sweep and Step-3 indicator->code pivots and drops you into Step 4 with a ranked list of the
+  functions that matter and the exact addresses to r2_decompile. Load map.json at r2_init_project
+  time. It is reconnaissance, not analysis: it never satisfies your hard gate — you still read every
+  body before you claim it.
+---
+
+# xrefer-agent-map (a format_binary accelerator)
+
+## 1. What it is and where it fits
+
+This is **not** a replacement for `format_binary` — it plugs into it. xrefer already ran whole-program
+analysis on this sample and produced a **curated, de-noised, semantically-grouped** version of the
+triage and pivots you would do by hand: clustered imports/strings/capa, a precomputed `r2_xrefs_to`,
+whole-program reachability, and an LLM interpretation layer. Its job is to spend your r2 budget where
+it matters — it tells you **where to point `r2_decompile`**, not what the code does. The tiered layout
+is for binaries too large for the single-file `binary_anatomy`: everything is split across files and
+**lazy-loaded** — fetch only what a given pivot needs.
+
+**Load `map.json` at `r2_init_project` time** if a bundle exists for this sha256. Then run the normal
+6 steps — `schema.workflow_binding.section_to_step` maps each section to the step it accelerates.
+
+## 2. THE HARD GATE STILL APPLIES (read this twice)
+
+Everything with `"provenance":"llm"` — cluster `label`, `function_prefix`, `mitre`, the `binary`
+verdict, each `one_line` — is a **"listing": a hypothesis that satisfies your gate for nothing.** Your
+rule is unchanged: *no capability claim without a function body read; no confirmed function left
+unnamed; rename only on evidence.* The map's value is that it names **exactly which body** proves each
+hypothesis (`llm.verify_against.key_function_rvas` / `static.artifacts.*.call_site_rvas`). A report
+assembled from this map alone is the "listing is not reverse engineering" failure. Facts you may state
+directly are only the `"provenance":"static"` ones (RVAs, artifact names, xrefs, paths, capa,
+classification). See `provenance_legend` — and its `correction`: cluster `is_library` /
+`library_kind=="llm"` and per-function `origin` are LLM-DERIVED, not skip authority.
+
+## 3. Addressing, keys, and binding
+
+- `r2_addr = r2_baddr + rva` (see `image.recipe`). For a normally-mapped image `r2_baddr ==
+  image.image_base_va`; if your session is rebased (PIE/ASLR/-B) substitute your own baddr and confirm
+  one known function first.
+- The bundle matches this sample **iff `image.sha256` == your `r2_init_project` sha256.** If it does
+  not, do not apply these RVAs or any rename — it is a different sample.
+- **Cluster identity is `root_rva`** (also the address to `r2_decompile`). `run_ref` (`cluster.id.NNNN`)
+  is run-local — never use it as a stable key.
+
+## 4. Step-by-step: how the map folds into format_binary
+
+**Step 1 (init)** — after `r2_init_project`, load `map.json`. Read `entry_anchor` (application vs
+runtime roots; `read_first_rva`), `stats`, the `binary` verdict (a hypothesis), and the `mitre`
+kill-chain. Check `stats.backend_live` (see §7).
+
+**Step 2 (triage) — mostly done for you.** Use `investigation_queue` instead of a blind sweep, and
+`indices/entities.json` (curated, de-noised) instead of raw `r2_imports`/`r2_find_regex`. This is the
+fix for the Go / statically-linked **blind-regex failure**: xrefer already separated signal from the
+tens-of-thousands-of-strings noise. Spot-check with `r2_find_regex` only if the map looks thin.
+
+**Step 3 (pivot) — precomputed.** `indices/reverse_index.json["<entity_idx>"].function_rvas` is your
+`r2_xrefs_to` result (artifact → referencing functions). A large `indices/functions.json[fn].indirect`
+count is xrefer naming the dispatcher/hub you would otherwise hunt with `r2_callees`.
+`indices/reachability.json["<rva>"]` gives `reachable` / `min_depth` / `shortest_path_rvas` / `n_paths`
+(a whole-program path from entry — not a single r2 call).
+
+**Step 4 (read the bodies) — THIS IS STILL YOUR JOB.** Walk `investigation_queue` top-down (it is
+score-ranked; each item's `first_move` is a ready r2 call and `detail_ref` names its Tier-1 file). For
+each item open `clusters/<root_rva>.json`:
+- `r2_decompile` the functions in `static.functions`, jumping to `static.artifacts.*.call_site_rvas`
+  (the exact instructions). **Skip a function only on the STATIC signals** `category=="func_lib"` /
+  `is_simple_api_thunk` (prioritize `origin:"user"`), never on the LLM library framing.
+- `static.edges` is the cluster's real call graph; `static.subcluster_refs` are trustworthy call
+  linkages into child clusters (`child_root_rva`).
+- Use `llm.verify_against.key_function_rvas` as the must-read set and `llm.mitre[].rationale` as the
+  claim to confirm. `llm.resolved_relationships` pre-resolves the cluster's prose `cluster.id.NNNN`
+  references to root RVAs; `llm.unresolved_run_ids` is an honest gap — do not invent that edge.
+
+**Step 5 (annotate) — on evidence.** After you confirm a function, name it what the body does with
+`r2_rename` and `r2_set_comments` (xrefer supplies `llm.function_prefix` as a *suggested* prefix only —
+a hypothesis, not a name to apply blind). Never apply a name you have not earned by reading the body.
+`r2_save_project` at the end of a block.
+
+**Step 6 (report)** — re-check the hard gate: every capability must trace to a body you read. Speak
+MITRE technique-ids aligned with the `mitre` kill-chain (`tactics_kill_chain_order`; each technique's
+`groundings[].cluster_root_rva` + `cluster_root_rvas` point at the clusters to confirm; `empty_tactics`
+are unmapped). Build the report from **static counts + behaviors you confirmed**, citing
+addresses/functions — **not** from `indices/report.md` (LLM narrative, reference only; its header says
+so). Mark any xrefer hypothesis you could not confirm as unverified. Pivot IOCs through
+`get_context_for_hash` / `get_ioc_assessment` and drop noisy ones.
+
+## 5. Query cookbook (map field → next r2 call)
+
+- *Which functions reference this API/IOC?* → `reverse_index["<entity_idx>"].function_rvas` →
+  `r2_decompile` each.
+- *How does entry reach function Y?* → `reachability["<Y>"].shortest_path_rvas` (with `n_paths`).
+- *Where is the dispatcher / config-gating hub?* → highest `functions.json[fn].indirect` in scope.
+- *What does function W touch, and exactly where?* → its cluster's `static.artifacts.*.call_site_rvas`.
+- *An artifact-bearing function with no path from entry?* → `orphans_index[]`; `r2_xrefs_to` it (the
+  item's `next` field) to find the caller r2's static pass missed.
+- *Resolve an entity_idx to a name/group/xref count?* → `indices/entities.json`.
+
+## 6. Noise, library demotion, completeness
+
+Do not conclude "clean" just because the queue is short — the safety net is **static**:
+- `clusters_index` lists **every** cluster (signal + demoted). A row with `is_library:true` and
+  `detail_ref:null` was excluded from the queue and Tier-1. `library_kind` distinguishes `"static"`
+  (deterministic FUNC_LIB — safe to skip) from `"llm"` (the `library_or_runtime` guess — a **budget
+  lever**: skip to save decompiler budget, but it is visible, not triaged).
+- Any cluster with `danger_floor` set (process-injection / crypto / net-exfil / cred-access imports) or
+  `promoted_from_noise:true` reaches the danger set statically and is force-kept in the queue even if
+  the LLM called it library — so a mislabeled payload cannot hide. Never skip on the LLM library flag
+  when a static `danger_floor` disagrees.
+- `stats.clusters_excluded_from_tier1` tells you how many clusters were demoted; a mislabeled cluster
+  is recoverable — re-examine one if you suspect it (`stats.note`).
+
+## 7. Degraded mode and backend_live
+
+- **`schema.has_llm_layer:false`** → `binary`, `mitre`, every cluster `llm` block, and the labels in
+  `clusters_index`/`investigation_queue` are null, and the queue is scored on static signals only.
+  The static skeleton (clusters, edges, artifacts+call sites, reachability, reverse index, orphans,
+  danger_floor) is still a complete Step-2/3 accelerator — proceed on structure, derive the verdict
+  yourself. No `"provenance":"llm"` value exists in the bundle, so nothing needs de-hypothesizing —
+  you still read the bodies as always.
+- **`stats.backend_live:false`** → this bundle was exported headless from a cached analysis where the
+  live disassembler backend was unavailable, so per-function `has_default_name` is `null` and
+  `category`/`origin` come from persisted cluster membership (static `func_lib` detection needs the
+  live backend, i.e. the in-tool export). Trust `category`/`origin` as membership-derived; treat
+  `has_default_name:null` as "unknown," not "false."
+
+## 8. Anti-patterns
+
+Do NOT: report a capability you only saw in the map (no body read); apply a `function_prefix` before
+verifying; treat `label`/`mitre`/the `binary` verdict as fact; use absolute VAs or `run_ref` as stable
+keys; ask the map for a full callgraph or all-paths you can get from r2; or treat the map as exhaustive
+(library/orphan functions it demotes still exist — `stats.clusters_excluded_from_tier1` names what was
+skipped).
+
+## Fields NOT in this bundle (do not look for them)
+
+The shipped bundle deliberately omits fields that have no non-fabricated static source: per-cluster
+`recipe`/`pattern` strings, crypto `carve_targets`, staged `suggested_annotations`, and `all_paths_ref`
+sidecars. Confirm crypto by decompiling the routine and carving its data references yourself; recover
+extra paths with `r2_callees`. `indices/entities.json` carries no LLM `enrichment` — kind/group/name/
+xref_count are the static facts.

--- a/plugins/xrefer/data/agent_skills/xrefer_binary_anatomy.md
+++ b/plugins/xrefer/data/agent_skills/xrefer_binary_anatomy.md
@@ -1,5 +1,5 @@
 ---
-name: binary_anatomy
+name: xrefer_binary_anatomy
 description: >-
   Consume an xrefer "binary anatomy" — a single, chat-pasteable JSON map of a native binary
   (recognizable by _readme.format == "xrefer-binary-anatomy" and the _end.sentinel
@@ -9,7 +9,7 @@ description: >-
   replaces reading bodies: every claim still requires an r2_decompile (or r2_disasm when that fails).
 ---
 
-# binary_anatomy — consuming a single-file xrefer map
+# xrefer_binary_anatomy — consuming a single-file xrefer map
 
 ## Prerequisite
 

--- a/plugins/xrefer/gui/action_handlers.py
+++ b/plugins/xrefer/gui/action_handlers.py
@@ -920,6 +920,40 @@ class GenerateHtmlReportHandler(idaapi.action_handler_t):
         return idaapi.AST_DISABLE
 
 
+class GenerateAgentAnatomyHandler(idaapi.action_handler_t):
+    """
+    Export the agent-facing "binary anatomy" JSON (single file) to
+    <binary_path>_anatomy.json, for an external malware-analysis agent
+    (radare2 / format_binary). Works with or without the LLM layer: if cluster
+    analysis has not run, a valid static-only map is still emitted.
+    """
+
+    def activate(self, ctx: Any) -> bool:
+        from xrefer.plugin import plugin_instance
+
+        try:
+            from xrefer.core.agent_map import export_anatomy
+
+            xo = plugin_instance.xrefer_view.xrefer_obj
+            out_path = f"{xo._backend.path}_anatomy.json"
+            export_anatomy(xo, out_path)
+            log(f"[+] Agent anatomy written to: {out_path}")
+            return True
+        except Exception as e:
+            log(f"[-] Error exporting agent anatomy: {str(e)}")
+            import traceback
+
+            traceback.print_exc()
+            return False
+
+    def update(self, ctx: Any) -> int:
+        from xrefer.plugin import plugin_instance
+
+        if plugin_instance.xrefer_view and getattr(plugin_instance.xrefer_view, "xrefer_obj", None):
+            return idaapi.AST_ENABLE_ALWAYS
+        return idaapi.AST_DISABLE
+
+
 class SyncImageBaseHandler(idaapi.action_handler_t):
     """
     Handler for synchronizing image base addresses.

--- a/plugins/xrefer/gui/action_handlers.py
+++ b/plugins/xrefer/gui/action_handlers.py
@@ -954,6 +954,41 @@ class GenerateAgentAnatomyHandler(idaapi.action_handler_t):
         return idaapi.AST_DISABLE
 
 
+class GenerateAgentMapHandler(idaapi.action_handler_t):
+    """
+    Export the tiered agent-map bundle (map.json + clusters/ + indices/) to
+    <binary_path>_agent_map/, for an external malware-analysis agent
+    (radare2 / format_binary). Carries the full uncurated projection split
+    across lazy-loaded files — for binaries too large for the single-file
+    anatomy. Works with or without the LLM layer.
+    """
+
+    def activate(self, ctx: Any) -> bool:
+        from xrefer.plugin import plugin_instance
+
+        try:
+            from xrefer.core.agent_map import export_agent_map
+
+            xo = plugin_instance.xrefer_view.xrefer_obj
+            out_dir = f"{xo._backend.path}_agent_map"
+            export_agent_map(xo, out_dir)
+            log(f"[+] Agent map bundle written to: {out_dir}/")
+            return True
+        except Exception as e:
+            log(f"[-] Error exporting agent map: {str(e)}")
+            import traceback
+
+            traceback.print_exc()
+            return False
+
+    def update(self, ctx: Any) -> int:
+        from xrefer.plugin import plugin_instance
+
+        if plugin_instance.xrefer_view and getattr(plugin_instance.xrefer_view, "xrefer_obj", None):
+            return idaapi.AST_ENABLE_ALWAYS
+        return idaapi.AST_DISABLE
+
+
 class SyncImageBaseHandler(idaapi.action_handler_t):
     """
     Handler for synchronizing image base addresses.

--- a/plugins/xrefer/lang/lang_rust.py
+++ b/plugins/xrefer/lang/lang_rust.py
@@ -827,8 +827,16 @@ class LangRust(LanguageBase):
         return "::".join(common_parts)
 
     def _ptr_size(self) -> int:
-        max_end = max(sec.end.value for sec in self.backend.get_sections())
-        return 8 if max_end > 0xFFFFFFFF else 4
+        # Mirrors RustStringParser._guess_ptr_size: an unguarded max() raises
+        # ValueError on a binary whose backend reports no sections, and this
+        # runs inside _process_if_rust, so it would abort ALL Rust analysis
+        # rather than just the pointer-size probe.
+        try:
+            max_end = max(sec.end.value for sec in self.backend.get_sections())
+            return 8 if max_end > 0xFFFFFFFF else 4
+        except Exception:
+            # Safe default (64-bit), same fallback as the sibling helper.
+            return 8
 
     def _read_ptr(self, addr: Address, size: int) -> Optional[int]:
         raw = self.backend.read_bytes(addr, size)

--- a/plugins/xrefer/plugin.py
+++ b/plugins/xrefer/plugin.py
@@ -81,6 +81,7 @@ class XReferPlugin(idaapi.plugin_t):
             register_menu_action("Edit/XRefer/Organize Functions/", "XRefer:remove_all_folders", "Remove All Folders", RemoveAllFoldersHandler())
             register_menu_action("Edit/XRefer/", "XRefer:generate_html_report", "Generate HTML Report", GenerateHtmlReportHandler())
             register_menu_action("Edit/XRefer/", "XRefer:generate_agent_anatomy", "Export Agent Anatomy (JSON)", GenerateAgentAnatomyHandler())
+            register_menu_action("Edit/XRefer/", "XRefer:generate_agent_map", "Export Agent Map (tiered bundle)", GenerateAgentMapHandler())
             register_menu_action("Edit/XRefer/", "XRefer:view_attack_matrix", "View ATT&CK Matrix", ViewAttackMatrixHandler())
             register_menu_action("Edit/XRefer/Configure", "XRefer:Rust:configure", "Configure", XReferSettingsHandler())
             register_menu_action("Edit/XRefer/About", "XRefer:Rust:about", "About", AboutDialogHandler())

--- a/plugins/xrefer/plugin.py
+++ b/plugins/xrefer/plugin.py
@@ -80,6 +80,7 @@ class XReferPlugin(idaapi.plugin_t):
             register_menu_action("Edit/XRefer/Organize Functions/", "XRefer:organize_folders", "Organize into Folders (library/user)", OrganizeFoldersHandler())
             register_menu_action("Edit/XRefer/Organize Functions/", "XRefer:remove_all_folders", "Remove All Folders", RemoveAllFoldersHandler())
             register_menu_action("Edit/XRefer/", "XRefer:generate_html_report", "Generate HTML Report", GenerateHtmlReportHandler())
+            register_menu_action("Edit/XRefer/", "XRefer:generate_agent_anatomy", "Export Agent Anatomy (JSON)", GenerateAgentAnatomyHandler())
             register_menu_action("Edit/XRefer/", "XRefer:view_attack_matrix", "View ATT&CK Matrix", ViewAttackMatrixHandler())
             register_menu_action("Edit/XRefer/Configure", "XRefer:Rust:configure", "Configure", XReferSettingsHandler())
             register_menu_action("Edit/XRefer/About", "XRefer:Rust:about", "About", AboutDialogHandler())

--- a/tests/test_agent_map.py
+++ b/tests/test_agent_map.py
@@ -201,6 +201,23 @@ def test_anatomy_builds_and_has_static_truth():
     assert inj["llm"]["provenance"] == "llm"
 
 
+def test_single_file_cluster_cap_is_single_file_only(monkeypatch):
+    """The top-N cap bounds the single file (danger-floor clusters cut by it are
+    flagged, never silently dropped) and does NOT touch the tiered bundle."""
+    import xrefer.core.agent_map as am
+    monkeypatch.setattr(am, "MAX_SINGLE_FILE_CLUSTERS", 0)  # force the one signal cluster past the cap
+    d = build_anatomy(_XRefer())
+    assert d["clusters"] == []
+    assert d["investigation_queue"] == []
+    # the capped cluster reaches a danger floor -> surfaced in the anti-hiding ledger, not hidden
+    notable = {n["rva"] for n in d["coverage"]["omitted"]["notable_rvas"]}
+    assert rva(0x402000) in notable
+    # the tiered bundle ignores the single-file cap entirely
+    mp = build_agent_map(_XRefer())["map"]
+    assert any(c["ref"] == rva(0x402000) for c in mp["investigation_queue"])
+    assert rva(0x402000) in build_agent_map(_XRefer())["clusters"]
+
+
 # --------------------------------------------------------------------------
 # tiered bundle: structure + provenance + cross-refs
 # --------------------------------------------------------------------------

--- a/tests/test_agent_map.py
+++ b/tests/test_agent_map.py
@@ -320,33 +320,22 @@ def test_category_and_origin_fallback_without_live_backend():
     assert row["has_default_name"] is None  # needs live backend
 
 
-def test_dependency_bom_surfaces_crates_both_formats():
-    """The crate BOM (option ii) surfaces a cluster-local crypto crate in both
-    formats, and per-function libs (option i) re-appear on the artifact-bearing
-    member of the single file, signal-filtered."""
-    # single-file
+def test_signal_libs_on_cluster_functions_and_no_top_bom():
+    """Per-function libs re-appear on the artifact-bearing member (signal-filtered,
+    at their call sites) and there is NO separate top-level dependency_bom in either
+    format (it was reverted to keep libs only inside the clusters)."""
     d = build_anatomy(_XRefer())
-    bom = d["dependency_bom"]
-    sig = {r["crate"]: r for r in bom["signal"]}
-    assert "chacha20" in sig, "linked crypto crate must be a BOM signal entry"
-    assert sig["chacha20"]["clusters_rva"] == [rva(0x402000)]  # crate -> cluster bridge
-    assert sig["chacha20"]["n_clusters"] == 1
-    assert "entity_idxs" not in sig["chacha20"]                # lean single-file BOM
-    # tiny stub is below the pervasive-cluster floor, so nothing is demoted
-    assert bom["pervasive"] == []
-    assert d["_readme"]["counts"]["dependency_crates_signal"] >= 1
-    # option (i): the crate ref is back on the member function, at its call site
+    # the crate ref is on the member function, at its call site
     inj = next(c for c in d["clusters"] if c["root_rva"] == rva(0x402000))
     member = next(f for f in inj["static"]["functions"] if f["rva"] == rva(0x402100))
     libs = {l["name"]: l for l in member["artifacts"].get("libs", [])}
     assert "chacha20::chacha" in libs
     assert libs["chacha20::chacha"]["call_site_rvas"] == [rva(0x402160)]
-
-    # tiered map.json mirrors the BOM and carries entity_idxs (its full catalog resolves them)
-    mp = build_agent_map(_XRefer())["map"]
-    msig = {r["crate"]: r for r in mp["dependency_bom"]["signal"]}
-    assert "chacha20" in msig
-    assert 4 in msig["chacha20"]["entity_idxs"]
+    # no top-level BOM in the single file
+    assert "dependency_bom" not in d
+    assert "dependency_crates_signal" not in d["_readme"]["counts"]
+    # no top-level BOM in the tiered map either
+    assert "dependency_bom" not in build_agent_map(_XRefer())["map"]
 
 
 def test_no_bare_llm_values_at_top_level():

--- a/tests/test_agent_map.py
+++ b/tests/test_agent_map.py
@@ -33,7 +33,7 @@ from xrefer.core.agent_map import (
 )
 
 # Entity type ids (mirror EntityType: 1=lib 2=import 3=string 4=capa 5=api_trace).
-IMPORT, STRING, CAPA = 2, 3, 4
+LIB, IMPORT, STRING, CAPA = 1, 2, 3, 4
 
 IB = 0x400000
 EP = 0x401000
@@ -76,8 +76,8 @@ class _Backend:
         return None
 
 
-def _dxref(imports=None, strings=None, capa=None, imports_ea=None,
-           strings_ea=None, capa_ea=None):
+def _dxref(imports=None, strings=None, capa=None, libs=None, imports_ea=None,
+           strings_ea=None, capa_ea=None, libs_ea=None):
     z = {"libs": set(), "imports": set(), "strings": set(), "capa": set(),
          "api_trace": set(), "libs_ea": {}, "imports_ea": {}, "strings_ea": {},
          "capa_ea": {}, "api_trace_ea": {}}
@@ -87,9 +87,12 @@ def _dxref(imports=None, strings=None, capa=None, imports_ea=None,
         z["strings"] = set(strings)
     if capa:
         z["capa"] = set(capa)
+    if libs:
+        z["libs"] = set(libs)
     z["imports_ea"] = imports_ea or {}
     z["strings_ea"] = strings_ea or {}
     z["capa_ea"] = capa_ea or {}
+    z["libs_ea"] = libs_ea or {}
     return z
 
 
@@ -114,6 +117,7 @@ class _XRefer:
             ("kernel32", "WriteProcessMemory", IMPORT),  # 1
             ("rdata", "http://c2.example/beacon", STRING),  # 2
             ("host-interaction/process/inject", "inject process", CAPA),  # 3
+            ("crypto", "chacha20::chacha", LIB),         # 4 (cluster-local crate = BOM signal)
         ]
 
         # Signal cluster A: root 0x402000, member 0x402100 bears the artifacts.
@@ -130,16 +134,18 @@ class _XRefer:
         self.global_xrefs = {
             0x402000: [_dxref(), _dxref(imports={0, 1}, capa={3})],  # indirect hub
             0x402100: [
-                _dxref(imports={0, 1}, strings={2}, capa={3},
+                _dxref(imports={0, 1}, strings={2}, capa={3}, libs={4},
                        imports_ea={0: {0x402130}, 1: {0x402150}},
                        strings_ea={2: {0x402120}},
-                       capa_ea={3: {0x402150}}),
+                       capa_ea={3: {0x402150}},
+                       libs_ea={4: {0x402160}}),
                 _dxref(),
             ],
             0x403000: [_dxref(), _dxref()],
         }
 
-        self.entity_xrefs = {0: {0x402100}, 1: {0x402100}, 2: {0x402100}, 3: {0x402100}}
+        self.entity_xrefs = {0: {0x402100}, 1: {0x402100}, 2: {0x402100},
+                             3: {0x402100}, 4: {0x402100}}
 
         # paths from entry reach the signal root at depth 2.
         self.paths = {EP: {0x402000: [[EP, 0x401800, 0x402000]],
@@ -295,6 +301,35 @@ def test_category_and_origin_fallback_without_live_backend():
     assert row["category"] == "cluster_member"
     assert row["origin"] == "user"          # signal (non-library) cluster
     assert row["has_default_name"] is None  # needs live backend
+
+
+def test_dependency_bom_surfaces_crates_both_formats():
+    """The crate BOM (option ii) surfaces a cluster-local crypto crate in both
+    formats, and per-function libs (option i) re-appear on the artifact-bearing
+    member of the single file, signal-filtered."""
+    # single-file
+    d = build_anatomy(_XRefer())
+    bom = d["dependency_bom"]
+    sig = {r["crate"]: r for r in bom["signal"]}
+    assert "chacha20" in sig, "linked crypto crate must be a BOM signal entry"
+    assert sig["chacha20"]["clusters_rva"] == [rva(0x402000)]  # crate -> cluster bridge
+    assert sig["chacha20"]["n_clusters"] == 1
+    assert "entity_idxs" not in sig["chacha20"]                # lean single-file BOM
+    # tiny stub is below the pervasive-cluster floor, so nothing is demoted
+    assert bom["pervasive"] == []
+    assert d["_readme"]["counts"]["dependency_crates_signal"] >= 1
+    # option (i): the crate ref is back on the member function, at its call site
+    inj = next(c for c in d["clusters"] if c["root_rva"] == rva(0x402000))
+    member = next(f for f in inj["static"]["functions"] if f["rva"] == rva(0x402100))
+    libs = {l["name"]: l for l in member["artifacts"].get("libs", [])}
+    assert "chacha20::chacha" in libs
+    assert libs["chacha20::chacha"]["call_site_rvas"] == [rva(0x402160)]
+
+    # tiered map.json mirrors the BOM and carries entity_idxs (its full catalog resolves them)
+    mp = build_agent_map(_XRefer())["map"]
+    msig = {r["crate"]: r for r in mp["dependency_bom"]["signal"]}
+    assert "chacha20" in msig
+    assert 4 in msig["chacha20"]["entity_idxs"]
 
 
 def test_no_bare_llm_values_at_top_level():

--- a/tests/test_agent_map.py
+++ b/tests/test_agent_map.py
@@ -230,8 +230,27 @@ def test_investigation_queue_is_static_ranked():
     # first_move must target the cluster's own root (regression: it used to point at the
     # lowest-address shared member, which was wrong for most clusters)
     assert top["ref"] in top["first_move"]
+    # the depth floor is surfaced IN the queue and is the artifact-bearing member (0x402100),
+    # NOT the root — so the agent can't stop at the root without opening the dossier
+    assert top["must_read_rvas"] == [rva(0x402100)]
+    assert "must_read_rvas" in top["first_move"]
     # the label is NOT duplicated onto the queue; it lives once on clusters_index
     assert "one_line" not in top
+
+
+def test_must_read_rvas_matches_verify_against_both_formats():
+    b = build_agent_map(_XRefer())
+    q_top = b["map"]["investigation_queue"][0]
+    detail = b["clusters"][rva(0x402000)]
+    # the queue's depth floor and the dossier's verify_against are the SAME artifact-bearing set
+    assert q_top["must_read_rvas"] == detail["llm"]["verify_against"]["key_function_rvas"]
+    # single-file: verify_against is now artifact-bearing too (not sorted(nodes)[:6]) and the
+    # queue surfaces the same must_read_rvas
+    d = build_anatomy(_XRefer())
+    inj = next(c for c in d["clusters"] if c["root_rva"] == rva(0x402000))
+    aq = next(x for x in d["investigation_queue"] if x["ref_rva"] == rva(0x402000))
+    assert inj["llm"]["verify_against"]["key_function_rvas"] == [rva(0x402100)]
+    assert aq["must_read_rvas"] == [rva(0x402100)]
 
 
 def test_tier1_verify_against_points_at_real_functions():

--- a/tests/test_agent_map.py
+++ b/tests/test_agent_map.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 """Tests for the agent-facing exports (core/agent_map): the single-file
-``binary_anatomy`` and the tiered ``xrefer-agent-map`` bundle.
+``xrefer_binary_anatomy`` and the tiered ``xrefer-agent-map`` bundle.
 
 Everything runs on lightweight stubs (fake clusters + a hand-built
 global_xrefs / entities / paths / cluster_analysis + a dark backend). No IDA,
@@ -405,9 +405,9 @@ def test_export_anatomy_writes_json_and_companion_skill(tmp_path):
     d = json.loads(out.read_text())
     assert d["_end"]["sentinel"] == "XREFER_ANATOMY_EOF"
     # the single-file consumer skill lands beside the JSON (one-time install)
-    skill = tmp_path / "binary_anatomy.SKILL.md"
+    skill = tmp_path / "xrefer_binary_anatomy.SKILL.md"
     assert skill.exists()
-    assert "binary_anatomy" in skill.read_text()
+    assert "xrefer_binary_anatomy" in skill.read_text()
 
 
 def test_export_degrade_omits_report(tmp_path):

--- a/tests/test_agent_map.py
+++ b/tests/test_agent_map.py
@@ -227,8 +227,11 @@ def test_investigation_queue_is_static_ranked():
     top = q[0]
     assert top["ref"] == rva(0x402000)
     assert top["danger_floor"] == "process_injection"
-    # one_line is an llm hypothesis, tagged
-    assert top["one_line"]["provenance"] == "llm"
+    # first_move must target the cluster's own root (regression: it used to point at the
+    # lowest-address shared member, which was wrong for most clusters)
+    assert top["ref"] in top["first_move"]
+    # the label is NOT duplicated onto the queue; it lives once on clusters_index
+    assert "one_line" not in top
 
 
 def test_tier1_verify_against_points_at_real_functions():
@@ -298,12 +301,12 @@ def test_degrade_without_llm_layer():
     mp = b["map"]
     assert mp["schema"]["has_llm_layer"] is False
     assert mp["binary"]["category"] is None
-    assert mp["binary"]["report_present"] is False
+    assert mp["binary"]["report_ref"] is None
     assert mp["mitre"] is None
     assert b["report_md"] is None
-    # queue is still populated and purely static-scored
+    # queue is still populated and purely static-scored, with no LLM label duplicated in
     assert mp["investigation_queue"], "static queue must survive without LLM"
-    assert mp["investigation_queue"][0]["one_line"] is None
+    assert "one_line" not in mp["investigation_queue"][0]
     # signal cluster detail carries no llm block but full static evidence
     detail = b["clusters"][rva(0x402000)]
     assert detail["llm"] is None

--- a/tests/test_agent_map.py
+++ b/tests/test_agent_map.py
@@ -1,0 +1,339 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the agent-facing exports (core/agent_map): the single-file
+``binary_anatomy`` and the tiered ``xrefer-agent-map`` bundle.
+
+Everything runs on lightweight stubs (fake clusters + a hand-built
+global_xrefs / entities / paths / cluster_analysis + a dark backend). No IDA,
+backend, or LLM is needed, so the provenance discipline, RVA encoding,
+cross-file resolvability, manifest integrity, and degrade-without-LLM
+behaviour are all exercised deterministically.
+"""
+
+import json
+
+from xrefer.core.agent_map import (
+    GUESS,
+    build_agent_map,
+    build_anatomy,
+    export_agent_map,
+)
+
+# Entity type ids (mirror EntityType: 1=lib 2=import 3=string 4=capa 5=api_trace).
+IMPORT, STRING, CAPA = 2, 3, 4
+
+IB = 0x400000
+EP = 0x401000
+
+
+class _Cluster:
+    def __init__(self, cid, root, nodes, edges=None, is_library=False,
+                 parent=None, cluster_refs=None, subclusters=None):
+        self.id = cid
+        self.id_str = f"{cid:04d}"
+        self.root_node = root
+        self.nodes = set(nodes)
+        self.edges = edges or []
+        self.is_library = is_library
+        self.parent_cluster_id = parent
+        self.cluster_refs = cluster_refs or {}
+        self.subclusters = subclusters or []
+        self.intermediate_paths = {}
+
+
+class _Backend:
+    """A deliberately dark backend (get_function_at -> None) so the export
+    exercises its headless fallbacks, exactly like a load-from-cache CLI run."""
+
+    def __init__(self, path):
+        self.path = path
+        self.image_base = IB
+
+    @property
+    def binary_hash(self):
+        return "a" * 64
+
+    def filetype(self):
+        return "PE"
+
+    def get_function_at(self, address):
+        return None
+
+    def read_bytes(self, address, size):
+        return None
+
+
+def _dxref(imports=None, strings=None, capa=None, imports_ea=None,
+           strings_ea=None, capa_ea=None):
+    z = {"libs": set(), "imports": set(), "strings": set(), "capa": set(),
+         "api_trace": set(), "libs_ea": {}, "imports_ea": {}, "strings_ea": {},
+         "capa_ea": {}, "api_trace_ea": {}}
+    if imports:
+        z["imports"] = set(imports)
+    if strings:
+        z["strings"] = set(strings)
+    if capa:
+        z["capa"] = set(capa)
+    z["imports_ea"] = imports_ea or {}
+    z["strings_ea"] = strings_ea or {}
+    z["capa_ea"] = capa_ea or {}
+    return z
+
+
+class _XRefer:
+    """Minimal analysed-instance stub with two clusters: a signal cluster that
+    reaches a process-injection danger floor (reachable from entry) and an
+    LLM-flagged library cluster (demoted, no danger floor)."""
+
+    DIRECT_XREFS = 0
+    INDIRECT_XREFS = 1
+
+    def __init__(self, with_llm=True):
+        self.image_base = IB
+        self.current_analysis_ep = EP
+        self._backend = _Backend("/tmp/sample.bin")
+        self.lang = None
+
+        # entities: 2 injection imports, 1 string, 1 capa
+        # (group, name, type_id)
+        self.entities = [
+            ("kernel32", "VirtualAllocEx", IMPORT),      # 0
+            ("kernel32", "WriteProcessMemory", IMPORT),  # 1
+            ("rdata", "http://c2.example/beacon", STRING),  # 2
+            ("host-interaction/process/inject", "inject process", CAPA),  # 3
+        ]
+
+        # Signal cluster A: root 0x402000, member 0x402100 bears the artifacts.
+        # Library cluster B: root 0x403000 (is_library -> llm_lib, no danger).
+        self.clusters = [
+            _Cluster(1, 0x402000, [0x402000, 0x402100],
+                     edges=[(0x402000, 0x402100)],
+                     cluster_refs={0x402100: 2}),
+            _Cluster(2, 0x403000, [0x403000], is_library=True),
+        ]
+
+        # global_xrefs: 0x402100 references both imports (with call sites),
+        # the string, and the capa; the root gates them indirectly.
+        self.global_xrefs = {
+            0x402000: [_dxref(), _dxref(imports={0, 1}, capa={3})],  # indirect hub
+            0x402100: [
+                _dxref(imports={0, 1}, strings={2}, capa={3},
+                       imports_ea={0: {0x402130}, 1: {0x402150}},
+                       strings_ea={2: {0x402120}},
+                       capa_ea={3: {0x402150}}),
+                _dxref(),
+            ],
+            0x403000: [_dxref(), _dxref()],
+        }
+
+        self.entity_xrefs = {0: {0x402100}, 1: {0x402100}, 2: {0x402100}, 3: {0x402100}}
+
+        # paths from entry reach the signal root at depth 2.
+        self.paths = {EP: {0x402000: [[EP, 0x401800, 0x402000]],
+                           0x402100: [[EP, 0x401800, 0x402000, 0x402100]]}}
+
+        if with_llm:
+            self.cluster_analysis = {
+                "binary_category": "Backdoor",
+                "binary_description": "A test backdoor.",
+                "binary_report": "# Report\nSome narrative.",
+                "clusters": {
+                    "1": {
+                        "label": "Injector",
+                        "description": "Injects into a remote process.",
+                        "function_prefix": "inj",
+                        "relationships": "calls cluster.id.0002 for helpers",
+                        "library_or_runtime": 0,
+                        "mitre_attack": [
+                            {"id": "T1055", "tactic": "Defense Evasion",
+                             "name": "Process Injection", "rationale": "VAX+WPM."},
+                        ],
+                    },
+                },
+            }
+        else:
+            self.cluster_analysis = None
+
+    def classify_functions(self):
+        return {}
+
+    def is_simple_api_thunk(self, ea):
+        return False
+
+
+def rva(ea):
+    return f"0x{ea - IB:x}"
+
+
+# --------------------------------------------------------------------------
+# single-file anatomy
+# --------------------------------------------------------------------------
+
+def test_anatomy_builds_and_has_static_truth():
+    d = build_anatomy(_XRefer())
+    assert d["meta"]["has_llm_layer"] is True
+    assert d["_end"]["sentinel"] == "XREFER_ANATOMY_EOF"
+    # the injection cluster is a signal cluster reaching the danger floor
+    roots = {c["root_rva"] for c in d["clusters"]}
+    assert rva(0x402000) in roots
+    inj = next(c for c in d["clusters"] if c["root_rva"] == rva(0x402000))
+    assert inj["danger_floor"] == "process_injection"
+    # llm label is fenced, never bare
+    assert inj["llm"]["provenance"] == "llm"
+
+
+# --------------------------------------------------------------------------
+# tiered bundle: structure + provenance + cross-refs
+# --------------------------------------------------------------------------
+
+def test_bundle_structure_and_rva_encoding():
+    b = build_agent_map(_XRefer())
+    mp = b["map"]
+    assert mp["schema"]["format"] == "xrefer-agent-map"
+    assert mp["schema"]["has_llm_layer"] is True
+    assert mp["image"]["sha256"] == "a" * 64
+    assert mp["image"]["image_base_va"] == "0x400000"
+    assert mp["image"]["entry_points_rva"] == [rva(EP)]
+
+    # signal cluster gets a Tier-1 file; the library cluster does not.
+    idx = {c["root_rva"]: c for c in mp["clusters_index"]}
+    assert idx[rva(0x402000)]["detail_ref"] == f"clusters/{rva(0x402000)}.json"
+    assert idx[rva(0x402000)]["is_library"] is False
+    assert idx[rva(0x403000)]["is_library"] is True
+    assert idx[rva(0x403000)]["library_kind"] == "llm"
+    assert idx[rva(0x403000)]["detail_ref"] is None
+    assert rva(0x402000) in b["clusters"]
+    assert rva(0x403000) not in b["clusters"]
+
+
+def test_investigation_queue_is_static_ranked():
+    mp = build_agent_map(_XRefer())["map"]
+    q = mp["investigation_queue"]
+    assert [x["rank"] for x in q] == list(range(1, len(q) + 1))
+    assert all(q[i]["score"] >= q[i + 1]["score"] for i in range(len(q) - 1))
+    top = q[0]
+    assert top["ref"] == rva(0x402000)
+    assert top["danger_floor"] == "process_injection"
+    # one_line is an llm hypothesis, tagged
+    assert top["one_line"]["provenance"] == "llm"
+
+
+def test_tier1_verify_against_points_at_real_functions():
+    b = build_agent_map(_XRefer())
+    detail = b["clusters"][rva(0x402000)]
+    fn_rvas = {f["rva"] for f in detail["static"]["functions"]}
+    va = detail["llm"]["verify_against"]["key_function_rvas"]
+    assert va, "verify_against must name at least one function"
+    assert set(va) <= fn_rvas
+    # the artifact-bearing member (0x402100), not just the root, is the target
+    assert rva(0x402100) in va
+    # edges are preserved in the tiered detail (dropped only in the single file)
+    assert [rva(0x402000), rva(0x402100)] in detail["static"]["edges"]
+
+
+def test_relationship_run_refs_resolve_to_roots():
+    b = build_agent_map(_XRefer())
+    llm = b["clusters"][rva(0x402000)]["llm"]
+    resolved = {r["run_ref"]: r["resolved_to_root_rva"] for r in llm["resolved_relationships"]}
+    # "cluster.id.0002" in the prose -> cluster 2's root RVA
+    assert resolved.get("cluster.id.0002") == rva(0x403000)
+    assert llm["unresolved_run_ids"] == []
+
+
+def test_reverse_index_and_reachability():
+    b = build_agent_map(_XRefer())
+    rev = b["indices"]["reverse_index.json"]
+    # entity 0 (VirtualAllocEx) referenced by 0x402100
+    assert rev["0"]["function_rvas"] == [rva(0x402100)]
+    reach = b["indices"]["reachability.json"]
+    assert reach[rva(0x402000)]["reachable"] is True
+    assert reach[rva(0x402000)]["min_depth"] == 2
+
+
+def test_category_and_origin_fallback_without_live_backend():
+    # backend is dark (get_function_at -> None) and classify_functions -> {},
+    # so category/origin must fall back to persisted cluster membership.
+    b = build_agent_map(_XRefer())
+    fi = b["indices"]["functions.json"]
+    assert b["map"]["stats"]["backend_live"] is False
+    row = fi[rva(0x402100)]
+    assert row["category"] == "cluster_member"
+    assert row["origin"] == "user"          # signal (non-library) cluster
+    assert row["has_default_name"] is None  # needs live backend
+
+
+def test_no_bare_llm_values_at_top_level():
+    """Every LLM-derived scalar must be fenced (src==GUESS, provenance=='llm',
+    or inside an llm/one_line/label block) — never a bare fact."""
+    mp = build_agent_map(_XRefer())["map"]
+    # binary verdict is explicitly llm-provenanced
+    assert mp["binary"]["provenance"] == "llm"
+    # mitre block is llm-provenanced
+    assert mp["mitre"]["provenance"] == "llm"
+    # clusters_index labels are wrapped
+    for c in mp["clusters_index"]:
+        if c["label"] is not None:
+            assert c["label"]["provenance"] == "llm"
+
+
+# --------------------------------------------------------------------------
+# degrade: no LLM layer
+# --------------------------------------------------------------------------
+
+def test_degrade_without_llm_layer():
+    b = build_agent_map(_XRefer(with_llm=False))
+    mp = b["map"]
+    assert mp["schema"]["has_llm_layer"] is False
+    assert mp["binary"]["category"] is None
+    assert mp["binary"]["report_present"] is False
+    assert mp["mitre"] is None
+    assert b["report_md"] is None
+    # queue is still populated and purely static-scored
+    assert mp["investigation_queue"], "static queue must survive without LLM"
+    assert mp["investigation_queue"][0]["one_line"] is None
+    # signal cluster detail carries no llm block but full static evidence
+    detail = b["clusters"][rva(0x402000)]
+    assert detail["llm"] is None
+    assert detail["static"]["artifacts"]["apis"]
+
+
+# --------------------------------------------------------------------------
+# on-disk export: files + manifest integrity
+# --------------------------------------------------------------------------
+
+def test_export_writes_bundle_with_consistent_manifest(tmp_path):
+    out = tmp_path / "bundle"
+    export_agent_map(_XRefer(), str(out))
+
+    mp = json.loads((out / "map.json").read_text())
+    # every manifest entry exists and its byte size matches the file on disk
+    for f in mp["manifest"]["tier1_files"] + mp["manifest"]["tier2"]:
+        p = out / f["path"]
+        assert p.exists(), f["path"]
+        assert p.stat().st_size == f["bytes"]
+    # every detail_ref resolves
+    for c in mp["clusters_index"]:
+        if c["detail_ref"]:
+            assert (out / c["detail_ref"]).exists()
+    # report.md present with the llm layer
+    assert (out / "indices" / "report.md").exists()
+
+
+def test_export_degrade_omits_report(tmp_path):
+    out = tmp_path / "bundle_nollm"
+    export_agent_map(_XRefer(with_llm=False), str(out))
+    assert not (out / "indices" / "report.md").exists()
+    mp = json.loads((out / "map.json").read_text())
+    assert all(t["path"] != "indices/report.md" for t in mp["manifest"]["tier2"])

--- a/tests/test_agent_map.py
+++ b/tests/test_agent_map.py
@@ -29,6 +29,7 @@ from xrefer.core.agent_map import (
     build_agent_map,
     build_anatomy,
     export_agent_map,
+    export_anatomy,
 )
 
 # Entity type ids (mirror EntityType: 1=lib 2=import 3=string 4=capa 5=api_trace).
@@ -329,6 +330,21 @@ def test_export_writes_bundle_with_consistent_manifest(tmp_path):
             assert (out / c["detail_ref"]).exists()
     # report.md present with the llm layer
     assert (out / "indices" / "report.md").exists()
+    # the consumer skill ships inside the bundle and is named in the manifest
+    assert (out / "SKILL.md").exists()
+    assert mp["manifest"]["skill"] == "SKILL.md"
+    assert "xrefer-agent-map" in (out / "SKILL.md").read_text()  # the real skill content
+
+
+def test_export_anatomy_writes_json_and_companion_skill(tmp_path):
+    out = tmp_path / "anatomy.json"
+    export_anatomy(_XRefer(), str(out))
+    d = json.loads(out.read_text())
+    assert d["_end"]["sentinel"] == "XREFER_ANATOMY_EOF"
+    # the single-file consumer skill lands beside the JSON (one-time install)
+    skill = tmp_path / "binary_anatomy.SKILL.md"
+    assert skill.exists()
+    assert "binary_anatomy" in skill.read_text()
 
 
 def test_export_degrade_omits_report(tmp_path):

--- a/tests/test_thunk_xrefs_light_mode.py
+++ b/tests/test_thunk_xrefs_light_mode.py
@@ -1,0 +1,136 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""fix_thunk_xrefs must forward a thunk's import onto a caller that has no
+global_xrefs entry of its own.
+
+global_xrefs entries are created for artifact-bearing functions, plus — in
+FULL mode only — every path node via propagate_xref_nodes(). fix_thunk_xrefs
+runs in BOTH modes (see tests/test_light_mode_gating.py), so in light mode it
+regularly meets a (caller, thunk-leaf) pair whose CALLER has no entry.
+Indexing that caller raised KeyError and aborted the whole analysis before
+clustering (observed on a Rust PE via the Ghidra backend: KeyError 6010912 /
+0x5bb820).
+
+Skipping such callers is not an acceptable fix either: it would silently drop
+the thunk's import from the caller in light mode only, which is exactly the
+light-vs-full report divergence test_light_mode_gating.py guards against. The
+entry must be CREATED and the import forwarded, matching full-mode semantics.
+"""
+
+from xrefer.core.analyzer import XRefer
+
+XT = ("libs", "imports", "strings", "capa", "api_trace")
+SUFFIX = {"libs": "libs_ea", "imports": "imports_ea", "strings": "strings_ea", "capa": "capa_ea", "api_trace": "api_trace_ea"}
+EP = 0x1000
+CALLER = 0x2000       # bears no artifacts -> no global_xrefs entry in light mode
+THUNK_LEAF = 0x3000   # artifact-bearing thunk -> has an entry
+IMPORT_NODE = 42
+CALL_SITE = 0x2010
+
+
+def _template():
+    entry = {t: set() for t in XT}
+    entry.update({SUFFIX[t]: {} for t in XT})
+    return entry
+
+
+class _Fn:
+    def __init__(self, start, is_thunk):
+        self.start = start
+        self.is_thunk = is_thunk
+
+
+class _FakeBackend:
+    """Only get_function_at is exercised by fix_thunk_xrefs."""
+
+    def __init__(self, thunks):
+        self._thunks = thunks
+
+    def get_function_at(self, ea):
+        return _Fn(int(ea), int(ea) in self._thunks)
+
+
+def _xrefer_with_unseeded_caller():
+    """Light-mode state: only the thunk leaf has a global_xrefs entry."""
+    xr = object.__new__(XRefer)
+    xr.current_analysis_ep = EP
+    # One path EP -> CALLER -> THUNK_LEAF, so last_edges == [(CALLER, THUNK_LEAF)]
+    xr.paths = {EP: {THUNK_LEAF: [[EP, CALLER, THUNK_LEAF]]}}
+    xr.entity_suffix_map = dict(SUFFIX)
+    xr._backend = _FakeBackend({THUNK_LEAF})
+    xr.caller_xrefs_cache = {CALLER: {THUNK_LEAF: {CALL_SITE}}}
+    xr.entity_xrefs = {IMPORT_NODE: set()}
+
+    leaf_entry = {
+        XRefer.DIRECT_XREFS: _template(),
+        XRefer.INDIRECT_XREFS: _template(),
+        XRefer.COMBINED_XREFS: set(),
+    }
+    leaf_entry[XRefer.DIRECT_XREFS]["imports"] = {IMPORT_NODE}
+    xr.global_xrefs = {THUNK_LEAF: leaf_entry}
+    return xr
+
+
+def test_thunk_forwarding_survives_caller_without_global_xrefs_entry():
+    """The KeyError regression: must not raise, and must forward the import."""
+    xr = _xrefer_with_unseeded_caller()
+    assert CALLER not in xr.global_xrefs
+
+    xr.fix_thunk_xrefs()  # used to raise KeyError(CALLER)
+
+    assert CALLER in xr.global_xrefs, "caller entry must be created, not skipped"
+    direct = xr.global_xrefs[CALLER][XRefer.DIRECT_XREFS]
+    assert IMPORT_NODE in direct["imports"], "thunk import must reach the caller"
+    assert direct["imports_ea"][IMPORT_NODE] == {CALL_SITE}
+    assert CALL_SITE in xr.entity_xrefs[IMPORT_NODE]
+
+
+def test_light_mode_forwarding_matches_full_mode():
+    """Light mode (caller unseeded) must reach the same caller state as full
+    mode, where propagate_xref_nodes() pre-created the entry."""
+    light = _xrefer_with_unseeded_caller()
+    light.fix_thunk_xrefs()
+
+    full = _xrefer_with_unseeded_caller()
+    full.ensure_global_xrefs_entry(CALLER)  # what full mode does beforehand
+    full.fix_thunk_xrefs()
+
+    ld = light.global_xrefs[CALLER][XRefer.DIRECT_XREFS]
+    fd = full.global_xrefs[CALLER][XRefer.DIRECT_XREFS]
+    assert ld["imports"] == fd["imports"]
+    assert ld["imports_ea"] == fd["imports_ea"]
+    assert light.entity_xrefs[IMPORT_NODE] == full.entity_xrefs[IMPORT_NODE]
+
+
+def test_non_thunk_leaf_is_left_alone():
+    """Guard against over-forwarding: a non-thunk leaf must not create or
+    touch a caller entry."""
+    xr = _xrefer_with_unseeded_caller()
+    xr._backend = _FakeBackend(set())  # leaf is NOT a thunk
+
+    xr.fix_thunk_xrefs()
+
+    assert CALLER not in xr.global_xrefs
+    assert xr.entity_xrefs[IMPORT_NODE] == set()
+
+
+def test_leaf_without_global_xrefs_entry_is_skipped():
+    """A leaf with no entry at all must be skipped, not created/indexed."""
+    xr = _xrefer_with_unseeded_caller()
+    xr.global_xrefs = {}  # neither side seeded
+
+    xr.fix_thunk_xrefs()  # must not raise
+
+    assert xr.global_xrefs == {}


### PR DESCRIPTION
Two independent pieces of work plus release prep. 20 commits on top of `gsoc_2025`.

No vivisect or contributor-fork code is involved. Verified on the pushed tip:
zero vivisect files, zero references to `recover_incomplete_call_graph`,
`_connectivity_guarded_ep` or `recover_vtable_edges`.

### 1. Fix: light-mode KeyError aborted analysis before clustering

`fix_thunk_xrefs()` indexed `global_xrefs[caller]` directly. Entries are created
for artifact-bearing functions, plus every path node via `propagate_xref_nodes()`,
which runs in FULL mode only. `fix_thunk_xrefs` runs in BOTH modes, so in light
mode (the CLI default) a thunk leaf whose caller carries no artifacts of its own
raised KeyError and killed the whole run before clustering.

Reproduced on a Rust PE with both backends:

| backend | before | after |
|---|---|---|
| ghidra | `KeyError: 6010912` (0x5bb820) | completes |
| ida | `KeyError: 5373984` (0x520be0) | completes |

IDA had already built 1126 call path groups before dying, so the loss was
larger there.

The fix creates the caller entry via `ensure_global_xrefs_entry()` rather than
skipping the forward. Skipping also stops the crash, but it drops the thunk's
import from the caller in light mode only, which is exactly the light vs full
report divergence that `tests/test_light_mode_gating.py` exists to prevent.
The thunk side is only read, so it is probed without creating an entry.

Both crashes above printed `Analysis completed successfully` and exited 0,
hiding a hard failure from scripted callers. Failed analyses now populate
`analysis_errors`, which the CLI already checks, so they exit non-zero.

New regression test `tests/test_thunk_xrefs_light_mode.py` (4 cases). Confirmed
it fails with KeyError on the unpatched analyzer and passes on the fixed one,
and that light-mode output now matches full mode.

### 2. Feature: agent-facing exporters and consumer skills

Emits structured JSON for an external analysis agent to consume.

- `--emit-anatomy [PATH]`: single-file `anatomy.json`, top-21 signal clusters,
  sha256 + RVA binding, deterministic investigation queue, explicit coverage
  accounting for omitted clusters.
- `--emit-agent-map [DIR]`: tiered bundle, `map.json` plus `clusters/` and
  `indices/` (entities, functions, reachability, reverse_index, report.md).
- Both ship a consumer skill describing the recursive decompile-or-disassemble
  loop over the queue.
- Also available as IDA menu actions.

### 3. Release prep

Version bumped to `1.1.20260804` in the single-source `_version.py`, which stays
import-free so setuptools can resolve it statically.

`lang_rust._ptr_size()` used an unguarded `max()` over backend sections, so a
binary reporting no sections raised ValueError. It runs inside
`_process_if_rust()`, so that aborted all Rust analysis rather than just the
pointer-size probe. It now mirrors `RustStringParser._guess_ptr_size` and falls
back to 8.

### Verification

- Suite: 344 passed, 22 skipped. Skips are backend availability only
  (binaryninja/ida not importable in the test env) and missing e2e samples.
- Thunk fix validated on real malware through both backends, patched and
  unpatched, as in the table above.
- Exporters validated end to end with the IDA backend and the LLM stage on:
  `anatomy.json` 147KB with 21 signal clusters and `has_llm=True`, tiered bundle
  1.71MB with 59 clusters and 5 index files. `bind_check.sha256` and
  `image.sha256` both match the real file hash.

### Not covered

The exporter GUI menu actions (`gui/action_handlers.py`, `plugin.py`) have not
been exercised in a live IDA session. The CLI paths for both exporters are
validated.