### PR TITLE
xrefer: fix import failure on Python older than 3.14

### DIFF
--- a/plugins/xrefer/backend/base.py
+++ b/plugins/xrefer/backend/base.py
@@ -7,7 +7,7 @@ from abc import ABC, abstractmethod
 from collections.abc import Iterator
 from dataclasses import dataclass
 from enum import Enum, auto
-from typing import Optional, Tuple
+from typing import List, Optional, Tuple
 
 # Common disassembler-generated function-name prefixes (IDA sub_/nullsub_/loc_,
 # Ghidra FUN_, Binary Ninja sub_). Used by Function.has_default_name's portable

--- a/plugins/xrefer/core/analyzer.py
+++ b/plugins/xrefer/core/analyzer.py
@@ -43,8 +43,13 @@ if TYPE_CHECKING:
 try:
     from idaapi import hide_wait_box, show_wait_box
 except ImportError:
+    # Kept out of the f-string expression: a backslash inside one is a
+    # SyntaxError before Python 3.12 (PEP 701 lifted the restriction), and
+    # pyproject declares requires-python >= 3.11.
+    _WAIT_BOX_PREFIX = "HIDECANCEL\n"
+
     def show_wait_box(message: str, *args, **kwargs) -> None:
-        print(f"Wait: {message.removeprefix('HIDECANCEL\n')}", *args, **kwargs)
+        print(f"Wait: {message.removeprefix(_WAIT_BOX_PREFIX)}", *args, **kwargs)
     def hide_wait_box(*args, **kwargs) -> None:
         print("Wait box hidden", *args, **kwargs)
 


### PR DESCRIPTION
Two defects that only surface below 3.14, so a 3.14 dev box never sees them while pyproject declares requires-python >= 3.11.

backend/base.py annotated Function.chunk_ranges with Optional[List[...]] but imported only Optional and Tuple. Python 3.14 evaluates annotations lazily (PEP 649), so the name is never resolved there; 3.11 through 3.13 evaluate at class-definition time and raise NameError: name 'List' is not defined, which aborts `import xrefer` entirely.

core/analyzer.py put a backslash inside an f-string expression (message.removeprefix('HIDECANCEL\n')) in the non-IDA show_wait_box fallback. PEP 701 allowed that only from 3.12, so 3.11 fails to even parse the module. Hoisted to a module-level constant.

Verified with real interpreters, not just static checks: compileall is clean on 3.11/3.12/3.13, `import xrefer` succeeds on 3.11 and 3.12, and the suite passes 344/22 on both.